### PR TITLE
[qtwayland] Fix scaling of refresh rate reported to wayland. JB#54674

### DIFF
--- a/src/compositor/wayland_wrapper/qwloutput.cpp
+++ b/src/compositor/wayland_wrapper/qwloutput.cpp
@@ -127,7 +127,7 @@ void Output::output_bind_resource(Resource *resource)
 
     send_mode(resource->handle, mode_current | mode_preferred,
               m_mode.size.width(), m_mode.size.height(),
-              m_mode.refreshRate);
+              m_mode.refreshRate * 1000);
 
     if (resource->version() >= 2) {
         send_scale(resource->handle, m_scaleFactor);


### PR DESCRIPTION
The value is supposed to be in mHz, all other places have correct scaling but this one place doesn't.