### PR TITLE
[qtwayland] Emit a signal when the client destroys a surface. Contributes to JB#52857

### DIFF
--- a/src/compositor/compositor_api/qwaylandsurface.h
+++ b/src/compositor/compositor_api/qwaylandsurface.h
@@ -253,6 +253,7 @@ Q_SIGNALS:
     void visibilityChanged();
     void pong();
     void surfaceDestroyed();
+    void clientDestroyedSurface();
 
     void configure(bool hasBuffer);
     void redraw();

--- a/src/compositor/wayland_wrapper/qwlsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlsurface.cpp
@@ -449,6 +449,8 @@ void Surface::surface_destroy_resource(Resource *)
 
 void Surface::surface_destroy(Resource *resource)
 {
+    emit m_waylandSurface->clientDestroyedSurface();
+
     wl_resource_destroy(resource->handle);
 }
 


### PR DESCRIPTION
Resurrecting the patches for JB#52857.