### PR TITLE
Compositor changes needed for Mozilla Firefox

### DIFF
--- a/src/3rdparty/protocol/wayland.xml
+++ b/src/3rdparty/protocol/wayland.xml
@@ -6,26 +6,26 @@
     Copyright © 2010-2011 Intel Corporation
     Copyright © 2012-2013 Collabora, Ltd.
 
-    Permission to use, copy, modify, distribute, and sell this
-    software and its documentation for any purpose is hereby granted
-    without fee, provided that the above copyright notice appear in
-    all copies and that both that copyright notice and this permission
-    notice appear in supporting documentation, and that the name of
-    the copyright holders not be used in advertising or publicity
-    pertaining to distribution of the software without specific,
-    written prior permission.  The copyright holders make no
-    representations about the suitability of this software for any
-    purpose.  It is provided "as is" without express or implied
-    warranty.
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation files
+    (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
 
-    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
-    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
-    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
-    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-    THIS SOFTWARE.
+    The above copyright notice and this permission notice (including the
+    next paragraph) shall be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+    ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
   </copyright>
 
   <interface name="wl_display" version="1">
@@ -46,9 +46,10 @@
 	compositor after the callback is fired and as such the client must not
 	attempt to use it after that point.
 
-	The callback_data passed in the callback is the event serial.
+	The callback_data passed in the callback is undefined and should be ignored.
       </description>
-      <arg name="callback" type="new_id" interface="wl_callback"/>
+      <arg name="callback" type="new_id" interface="wl_callback"
+	   summary="callback object for the sync request"/>
     </request>
 
     <request name="get_registry">
@@ -56,8 +57,15 @@
 	This request creates a registry object that allows the client
 	to list and bind the global objects available from the
 	compositor.
+
+	It should be noted that the server side resources consumed in
+	response to a get_registry request can only be released when the
+	client disconnects, not when the client side proxy is destroyed.
+	Therefore, clients should invoke get_registry as infrequently as
+	possible to avoid wasting memory.
       </description>
-      <arg name="registry" type="new_id" interface="wl_registry"/>
+      <arg name="registry" type="new_id" interface="wl_registry"
+	   summary="global registry object"/>
     </request>
 
     <event name="error">
@@ -67,12 +75,12 @@
 	where the error occurred, most often in response to a request
 	to that object.  The code identifies the error and is defined
 	by the object interface.  As such, each interface defines its
-	own set of error codes.  The message is an brief description
+	own set of error codes.  The message is a brief description
 	of the error, for (debugging) convenience.
       </description>
-      <arg name="object_id" type="object"/>
-      <arg name="code" type="uint"/>
-      <arg name="message" type="string"/>
+      <arg name="object_id" type="object" summary="object where the error occurred"/>
+      <arg name="code" type="uint" summary="error code"/>
+      <arg name="message" type="string" summary="error description"/>
     </event>
 
     <enum name="error">
@@ -83,27 +91,29 @@
       <entry name="invalid_object" value="0"
 	     summary="server couldn't find object"/>
       <entry name="invalid_method" value="1"
-	     summary="method doesn't exist on the specified interface"/>
+	     summary="method doesn't exist on the specified interface or malformed request"/>
       <entry name="no_memory" value="2"
 	     summary="server is out of memory"/>
+      <entry name="implementation" value="3"
+	     summary="implementation error in compositor"/>
     </enum>
 
     <event name="delete_id">
       <description summary="acknowledge object ID deletion">
 	This event is used internally by the object ID management
-	logic.  When a client deletes an object, the server will send
-	this event to acknowledge that it has seen the delete request.
-	When the client receive this event, it will know that it can
-	safely reuse the object ID.
+	logic. When a client deletes an object that it had created,
+	the server will send this event to acknowledge that it has
+	seen the delete request. When the client receives this event,
+	it will know that it can safely reuse the object ID.
       </description>
-      <arg name="id" type="uint" />
+      <arg name="id" type="uint" summary="deleted object ID"/>
     </event>
   </interface>
 
   <interface name="wl_registry" version="1">
     <description summary="global registry object">
-      The global registry object.  The server has a number of global
-      objects that are available to all clients.  These objects
+      The singleton global registry object.  The server has a number of
+      global objects that are available to all clients.  These objects
       typically represent an actual object in the server (for example,
       an input device) or they are singleton objects that provide
       extension functionality.
@@ -127,39 +137,39 @@
     <request name="bind">
       <description summary="bind an object to the display">
 	Binds a new, client-created object to the server using the
-        specified name as the identifier.
+	specified name as the identifier.
       </description>
-      <arg name="name" type="uint" summary="unique name for the object"/>
-      <arg name="id" type="new_id"/>
+      <arg name="name" type="uint" summary="unique numeric name of the object"/>
+      <arg name="id" type="new_id" summary="bounded object"/>
     </request>
 
     <event name="global">
       <description summary="announce global object">
 	Notify the client of global objects.
 
-        The event notifies the client that a global object with
-        the given name is now available, and it implements the
-        given version of the given interface.
+	The event notifies the client that a global object with
+	the given name is now available, and it implements the
+	given version of the given interface.
       </description>
-      <arg name="name" type="uint"/>
-      <arg name="interface" type="string"/>
-      <arg name="version" type="uint"/>
+      <arg name="name" type="uint" summary="numeric name of the global object"/>
+      <arg name="interface" type="string" summary="interface implemented by the object"/>
+      <arg name="version" type="uint" summary="interface version"/>
     </event>
 
     <event name="global_remove">
       <description summary="announce removal of global object">
 	Notify the client of removed global objects.
 
-        This event notifies the client that the global identified
-        by name is no longer available.  If the client bound to
-        the global using the bind request, the client should now
-        destroy that object.
+	This event notifies the client that the global identified
+	by name is no longer available.  If the client bound to
+	the global using the bind request, the client should now
+	destroy that object.
 
 	The object remains valid and requests to the object will be
 	ignored until the client destroys it, to avoid races between
 	the global going away and a client sending a request to it.
       </description>
-      <arg name="name" type="uint"/>
+      <arg name="name" type="uint" summary="numeric name of the global object"/>
     </event>
   </interface>
 
@@ -167,16 +177,20 @@
     <description summary="callback object">
       Clients can handle the 'done' event to get notified when
       the related request is done.
+
+      Note, because wl_callback objects are created from multiple independent
+      factory interfaces, the wl_callback interface is frozen at version 1.
     </description>
-    <event name="done">
+
+    <event name="done" type="destructor">
       <description summary="done event">
-       Notify the client when the related request is done.
+	Notify the client when the related request is done.
       </description>
-      <arg name="callback_data" type="uint" summary="request-specific data for the wl_callback"/>
+      <arg name="callback_data" type="uint" summary="request-specific data for the callback"/>
     </event>
   </interface>
 
-  <interface name="wl_compositor" version="3">
+  <interface name="wl_compositor" version="6">
     <description summary="the compositor singleton">
       A compositor.  This object is a singleton global.  The
       compositor is in charge of combining the contents of multiple
@@ -187,18 +201,18 @@
       <description summary="create new surface">
 	Ask the compositor to create a new surface.
       </description>
-      <arg name="id" type="new_id" interface="wl_surface"/>
+      <arg name="id" type="new_id" interface="wl_surface" summary="the new surface"/>
     </request>
 
     <request name="create_region">
       <description summary="create new region">
 	Ask the compositor to create a new region.
       </description>
-      <arg name="id" type="new_id" interface="wl_region"/>
+      <arg name="id" type="new_id" interface="wl_region" summary="the new region"/>
     </request>
   </interface>
 
-  <interface name="wl_shm_pool" version="1">
+  <interface name="wl_shm_pool" version="2">
     <description summary="a shared memory pool">
       The wl_shm_pool object encapsulates a piece of memory shared
       between the compositor and client.  Through the wl_shm_pool
@@ -214,8 +228,8 @@
 	Create a wl_buffer object from the pool.
 
 	The buffer is created offset bytes into the pool and has
-	width and height as specified.  The stride arguments specifies
-	the number of bytes from beginning of one row to the beginning
+	width and height as specified.  The stride argument specifies
+	the number of bytes from the beginning of one row to the beginning
 	of the next.  The format is the pixel format of the buffer and
 	must be one of those advertised through the wl_shm.format event.
 
@@ -223,13 +237,12 @@
 	so it is valid to destroy the pool immediately after creating
 	a buffer from it.
       </description>
-
-      <arg name="id" type="new_id" interface="wl_buffer"/>
-      <arg name="offset" type="int"/>
-      <arg name="width" type="int"/>
-      <arg name="height" type="int"/>
-      <arg name="stride" type="int"/>
-      <arg name="format" type="uint"/>
+      <arg name="id" type="new_id" interface="wl_buffer" summary="buffer to create"/>
+      <arg name="offset" type="int" summary="buffer byte offset within the pool"/>
+      <arg name="width" type="int" summary="buffer width, in pixels"/>
+      <arg name="height" type="int" summary="buffer height, in pixels"/>
+      <arg name="stride" type="int" summary="number of bytes from the beginning of one row to the beginning of the next row"/>
+      <arg name="format" type="uint" enum="wl_shm.format" summary="buffer pixel format"/>
     </request>
 
     <request name="destroy" type="destructor">
@@ -246,23 +259,29 @@
       <description summary="change the size of the pool mapping">
 	This request will cause the server to remap the backing memory
 	for the pool from the file descriptor passed when the pool was
-	created, but using the new size.
-      </description>
+	created, but using the new size.  This request can only be
+	used to make the pool bigger.
 
-      <arg name="size" type="int"/>
+	This request only changes the amount of bytes that are mmapped
+	by the server and does not touch the file corresponding to the
+	file descriptor passed at creation time. It is the client's
+	responsibility to ensure that the file is at least as big as
+	the new pool size.
+      </description>
+      <arg name="size" type="int" summary="new size of the pool, in bytes"/>
     </request>
   </interface>
 
-  <interface name="wl_shm" version="1">
+  <interface name="wl_shm" version="2">
     <description summary="shared memory support">
-      A global singleton object that provides support for shared
+      A singleton global object that provides support for shared
       memory.
 
       Clients can create wl_shm_pool objects using the create_pool
       request.
 
-      At connection setup time, the wl_shm object emits one or more
-      format events to inform clients about the valid pixel formats
+      On binding the wl_shm object one or more format events
+      are emitted to inform clients about the valid pixel formats
       that can be used for buffers.
     </description>
 
@@ -277,73 +296,144 @@
 
     <enum name="format">
       <description summary="pixel formats">
-       This describes the memory layout of an individual pixel.
+	This describes the memory layout of an individual pixel.
 
-       All renderers should support argb8888 and xrgb8888 but any other
-       formats are optional and may not be supported by the particular
-       renderer in use.
+	All renderers should support argb8888 and xrgb8888 but any other
+	formats are optional and may not be supported by the particular
+	renderer in use.
+
+	The drm format codes match the macros defined in drm_fourcc.h, except
+	argb8888 and xrgb8888. The formats actually supported by the compositor
+	will be reported by the format event.
+
+	For all wl_shm formats and unless specified in another protocol
+	extension, pre-multiplied alpha is used for pixel values.
       </description>
-      <entry name="argb8888" value="0" summary="32-bit ARGB format"/>
-      <entry name="xrgb8888" value="1" summary="32-bit RGB format"/>
-      <!-- The drm format codes match the #defines in drm_fourcc.h.
-           The formats actually supported by the compositor will be
-           reported by the format event. -->
-      <entry name="c8" value="0x20203843"/>
-      <entry name="rgb332" value="0x38424752"/>
-      <entry name="bgr233" value="0x38524742"/>
-      <entry name="xrgb4444" value="0x32315258"/>
-      <entry name="xbgr4444" value="0x32314258"/>
-      <entry name="rgbx4444" value="0x32315852"/>
-      <entry name="bgrx4444" value="0x32315842"/>
-      <entry name="argb4444" value="0x32315241"/>
-      <entry name="abgr4444" value="0x32314241"/>
-      <entry name="rgba4444" value="0x32314152"/>
-      <entry name="bgra4444" value="0x32314142"/>
-      <entry name="xrgb1555" value="0x35315258"/>
-      <entry name="xbgr1555" value="0x35314258"/>
-      <entry name="rgbx5551" value="0x35315852"/>
-      <entry name="bgrx5551" value="0x35315842"/>
-      <entry name="argb1555" value="0x35315241"/>
-      <entry name="abgr1555" value="0x35314241"/>
-      <entry name="rgba5551" value="0x35314152"/>
-      <entry name="bgra5551" value="0x35314142"/>
-      <entry name="rgb565" value="0x36314752"/>
-      <entry name="bgr565" value="0x36314742"/>
-      <entry name="rgb888" value="0x34324752"/>
-      <entry name="bgr888" value="0x34324742"/>
-      <entry name="xbgr8888" value="0x34324258"/>
-      <entry name="rgbx8888" value="0x34325852"/>
-      <entry name="bgrx8888" value="0x34325842"/>
-      <entry name="abgr8888" value="0x34324241"/>
-      <entry name="rgba8888" value="0x34324152"/>
-      <entry name="bgra8888" value="0x34324142"/>
-      <entry name="xrgb2101010" value="0x30335258"/>
-      <entry name="xbgr2101010" value="0x30334258"/>
-      <entry name="rgbx1010102" value="0x30335852"/>
-      <entry name="bgrx1010102" value="0x30335842"/>
-      <entry name="argb2101010" value="0x30335241"/>
-      <entry name="abgr2101010" value="0x30334241"/>
-      <entry name="rgba1010102" value="0x30334152"/>
-      <entry name="bgra1010102" value="0x30334142"/>
-      <entry name="yuyv" value="0x56595559"/>
-      <entry name="yvyu" value="0x55595659"/>
-      <entry name="uyvy" value="0x59565955"/>
-      <entry name="vyuy" value="0x59555956"/>
-      <entry name="ayuv" value="0x56555941"/>
-      <entry name="nv12" value="0x3231564e"/>
-      <entry name="nv21" value="0x3132564e"/>
-      <entry name="nv16" value="0x3631564e"/>
-      <entry name="nv61" value="0x3136564e"/>
-      <entry name="yuv410" value="0x39565559"/>
-      <entry name="yvu410" value="0x39555659"/>
-      <entry name="yuv411" value="0x31315559"/>
-      <entry name="yvu411" value="0x31315659"/>
-      <entry name="yuv420" value="0x32315559"/>
-      <entry name="yvu420" value="0x32315659"/>
-      <entry name="yuv422" value="0x36315559"/>
-      <entry name="yvu422" value="0x36315659"/>
-      <entry name="yuv444" value="0x34325559"/>
-      <entry name="yvu444" value="0x34325659"/>
+      <!-- Note to protocol writers: don't update this list manually, instead
+	   run the automated script that keeps it in sync with drm_fourcc.h. -->
+      <entry name="argb8888" value="0" summary="32-bit ARGB format, [31:0] A:R:G:B 8:8:8:8 little endian"/>
+      <entry name="xrgb8888" value="1" summary="32-bit RGB format, [31:0] x:R:G:B 8:8:8:8 little endian"/>
+      <entry name="c8" value="0x20203843" summary="8-bit color index format, [7:0] C"/>
+      <entry name="rgb332" value="0x38424752" summary="8-bit RGB format, [7:0] R:G:B 3:3:2"/>
+      <entry name="bgr233" value="0x38524742" summary="8-bit BGR format, [7:0] B:G:R 2:3:3"/>
+      <entry name="xrgb4444" value="0x32315258" summary="16-bit xRGB format, [15:0] x:R:G:B 4:4:4:4 little endian"/>
+      <entry name="xbgr4444" value="0x32314258" summary="16-bit xBGR format, [15:0] x:B:G:R 4:4:4:4 little endian"/>
+      <entry name="rgbx4444" value="0x32315852" summary="16-bit RGBx format, [15:0] R:G:B:x 4:4:4:4 little endian"/>
+      <entry name="bgrx4444" value="0x32315842" summary="16-bit BGRx format, [15:0] B:G:R:x 4:4:4:4 little endian"/>
+      <entry name="argb4444" value="0x32315241" summary="16-bit ARGB format, [15:0] A:R:G:B 4:4:4:4 little endian"/>
+      <entry name="abgr4444" value="0x32314241" summary="16-bit ABGR format, [15:0] A:B:G:R 4:4:4:4 little endian"/>
+      <entry name="rgba4444" value="0x32314152" summary="16-bit RBGA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
+      <entry name="bgra4444" value="0x32314142" summary="16-bit BGRA format, [15:0] B:G:R:A 4:4:4:4 little endian"/>
+      <entry name="xrgb1555" value="0x35315258" summary="16-bit xRGB format, [15:0] x:R:G:B 1:5:5:5 little endian"/>
+      <entry name="xbgr1555" value="0x35314258" summary="16-bit xBGR 1555 format, [15:0] x:B:G:R 1:5:5:5 little endian"/>
+      <entry name="rgbx5551" value="0x35315852" summary="16-bit RGBx 5551 format, [15:0] R:G:B:x 5:5:5:1 little endian"/>
+      <entry name="bgrx5551" value="0x35315842" summary="16-bit BGRx 5551 format, [15:0] B:G:R:x 5:5:5:1 little endian"/>
+      <entry name="argb1555" value="0x35315241" summary="16-bit ARGB 1555 format, [15:0] A:R:G:B 1:5:5:5 little endian"/>
+      <entry name="abgr1555" value="0x35314241" summary="16-bit ABGR 1555 format, [15:0] A:B:G:R 1:5:5:5 little endian"/>
+      <entry name="rgba5551" value="0x35314152" summary="16-bit RGBA 5551 format, [15:0] R:G:B:A 5:5:5:1 little endian"/>
+      <entry name="bgra5551" value="0x35314142" summary="16-bit BGRA 5551 format, [15:0] B:G:R:A 5:5:5:1 little endian"/>
+      <entry name="rgb565" value="0x36314752" summary="16-bit RGB 565 format, [15:0] R:G:B 5:6:5 little endian"/>
+      <entry name="bgr565" value="0x36314742" summary="16-bit BGR 565 format, [15:0] B:G:R 5:6:5 little endian"/>
+      <entry name="rgb888" value="0x34324752" summary="24-bit RGB format, [23:0] R:G:B little endian"/>
+      <entry name="bgr888" value="0x34324742" summary="24-bit BGR format, [23:0] B:G:R little endian"/>
+      <entry name="xbgr8888" value="0x34324258" summary="32-bit xBGR format, [31:0] x:B:G:R 8:8:8:8 little endian"/>
+      <entry name="rgbx8888" value="0x34325852" summary="32-bit RGBx format, [31:0] R:G:B:x 8:8:8:8 little endian"/>
+      <entry name="bgrx8888" value="0x34325842" summary="32-bit BGRx format, [31:0] B:G:R:x 8:8:8:8 little endian"/>
+      <entry name="abgr8888" value="0x34324241" summary="32-bit ABGR format, [31:0] A:B:G:R 8:8:8:8 little endian"/>
+      <entry name="rgba8888" value="0x34324152" summary="32-bit RGBA format, [31:0] R:G:B:A 8:8:8:8 little endian"/>
+      <entry name="bgra8888" value="0x34324142" summary="32-bit BGRA format, [31:0] B:G:R:A 8:8:8:8 little endian"/>
+      <entry name="xrgb2101010" value="0x30335258" summary="32-bit xRGB format, [31:0] x:R:G:B 2:10:10:10 little endian"/>
+      <entry name="xbgr2101010" value="0x30334258" summary="32-bit xBGR format, [31:0] x:B:G:R 2:10:10:10 little endian"/>
+      <entry name="rgbx1010102" value="0x30335852" summary="32-bit RGBx format, [31:0] R:G:B:x 10:10:10:2 little endian"/>
+      <entry name="bgrx1010102" value="0x30335842" summary="32-bit BGRx format, [31:0] B:G:R:x 10:10:10:2 little endian"/>
+      <entry name="argb2101010" value="0x30335241" summary="32-bit ARGB format, [31:0] A:R:G:B 2:10:10:10 little endian"/>
+      <entry name="abgr2101010" value="0x30334241" summary="32-bit ABGR format, [31:0] A:B:G:R 2:10:10:10 little endian"/>
+      <entry name="rgba1010102" value="0x30334152" summary="32-bit RGBA format, [31:0] R:G:B:A 10:10:10:2 little endian"/>
+      <entry name="bgra1010102" value="0x30334142" summary="32-bit BGRA format, [31:0] B:G:R:A 10:10:10:2 little endian"/>
+      <entry name="yuyv" value="0x56595559" summary="packed YCbCr format, [31:0] Cr0:Y1:Cb0:Y0 8:8:8:8 little endian"/>
+      <entry name="yvyu" value="0x55595659" summary="packed YCbCr format, [31:0] Cb0:Y1:Cr0:Y0 8:8:8:8 little endian"/>
+      <entry name="uyvy" value="0x59565955" summary="packed YCbCr format, [31:0] Y1:Cr0:Y0:Cb0 8:8:8:8 little endian"/>
+      <entry name="vyuy" value="0x59555956" summary="packed YCbCr format, [31:0] Y1:Cb0:Y0:Cr0 8:8:8:8 little endian"/>
+      <entry name="ayuv" value="0x56555941" summary="packed AYCbCr format, [31:0] A:Y:Cb:Cr 8:8:8:8 little endian"/>
+      <entry name="nv12" value="0x3231564e" summary="2 plane YCbCr Cr:Cb format, 2x2 subsampled Cr:Cb plane"/>
+      <entry name="nv21" value="0x3132564e" summary="2 plane YCbCr Cb:Cr format, 2x2 subsampled Cb:Cr plane"/>
+      <entry name="nv16" value="0x3631564e" summary="2 plane YCbCr Cr:Cb format, 2x1 subsampled Cr:Cb plane"/>
+      <entry name="nv61" value="0x3136564e" summary="2 plane YCbCr Cb:Cr format, 2x1 subsampled Cb:Cr plane"/>
+      <entry name="yuv410" value="0x39565559" summary="3 plane YCbCr format, 4x4 subsampled Cb (1) and Cr (2) planes"/>
+      <entry name="yvu410" value="0x39555659" summary="3 plane YCbCr format, 4x4 subsampled Cr (1) and Cb (2) planes"/>
+      <entry name="yuv411" value="0x31315559" summary="3 plane YCbCr format, 4x1 subsampled Cb (1) and Cr (2) planes"/>
+      <entry name="yvu411" value="0x31315659" summary="3 plane YCbCr format, 4x1 subsampled Cr (1) and Cb (2) planes"/>
+      <entry name="yuv420" value="0x32315559" summary="3 plane YCbCr format, 2x2 subsampled Cb (1) and Cr (2) planes"/>
+      <entry name="yvu420" value="0x32315659" summary="3 plane YCbCr format, 2x2 subsampled Cr (1) and Cb (2) planes"/>
+      <entry name="yuv422" value="0x36315559" summary="3 plane YCbCr format, 2x1 subsampled Cb (1) and Cr (2) planes"/>
+      <entry name="yvu422" value="0x36315659" summary="3 plane YCbCr format, 2x1 subsampled Cr (1) and Cb (2) planes"/>
+      <entry name="yuv444" value="0x34325559" summary="3 plane YCbCr format, non-subsampled Cb (1) and Cr (2) planes"/>
+      <entry name="yvu444" value="0x34325659" summary="3 plane YCbCr format, non-subsampled Cr (1) and Cb (2) planes"/>
+      <entry name="r8" value="0x20203852" summary="[7:0] R"/>
+      <entry name="r16" value="0x20363152" summary="[15:0] R little endian"/>
+      <entry name="rg88" value="0x38384752" summary="[15:0] R:G 8:8 little endian"/>
+      <entry name="gr88" value="0x38385247" summary="[15:0] G:R 8:8 little endian"/>
+      <entry name="rg1616" value="0x32334752" summary="[31:0] R:G 16:16 little endian"/>
+      <entry name="gr1616" value="0x32335247" summary="[31:0] G:R 16:16 little endian"/>
+      <entry name="xrgb16161616f" value="0x48345258" summary="[63:0] x:R:G:B 16:16:16:16 little endian"/>
+      <entry name="xbgr16161616f" value="0x48344258" summary="[63:0] x:B:G:R 16:16:16:16 little endian"/>
+      <entry name="argb16161616f" value="0x48345241" summary="[63:0] A:R:G:B 16:16:16:16 little endian"/>
+      <entry name="abgr16161616f" value="0x48344241" summary="[63:0] A:B:G:R 16:16:16:16 little endian"/>
+      <entry name="xyuv8888" value="0x56555958" summary="[31:0] X:Y:Cb:Cr 8:8:8:8 little endian"/>
+      <entry name="vuy888" value="0x34325556" summary="[23:0] Cr:Cb:Y 8:8:8 little endian"/>
+      <entry name="vuy101010" value="0x30335556" summary="Y followed by U then V, 10:10:10. Non-linear modifier only"/>
+      <entry name="y210" value="0x30313259" summary="[63:0] Cr0:0:Y1:0:Cb0:0:Y0:0 10:6:10:6:10:6:10:6 little endian per 2 Y pixels"/>
+      <entry name="y212" value="0x32313259" summary="[63:0] Cr0:0:Y1:0:Cb0:0:Y0:0 12:4:12:4:12:4:12:4 little endian per 2 Y pixels"/>
+      <entry name="y216" value="0x36313259" summary="[63:0] Cr0:Y1:Cb0:Y0 16:16:16:16 little endian per 2 Y pixels"/>
+      <entry name="y410" value="0x30313459" summary="[31:0] A:Cr:Y:Cb 2:10:10:10 little endian"/>
+      <entry name="y412" value="0x32313459" summary="[63:0] A:0:Cr:0:Y:0:Cb:0 12:4:12:4:12:4:12:4 little endian"/>
+      <entry name="y416" value="0x36313459" summary="[63:0] A:Cr:Y:Cb 16:16:16:16 little endian"/>
+      <entry name="xvyu2101010" value="0x30335658" summary="[31:0] X:Cr:Y:Cb 2:10:10:10 little endian"/>
+      <entry name="xvyu12_16161616" value="0x36335658" summary="[63:0] X:0:Cr:0:Y:0:Cb:0 12:4:12:4:12:4:12:4 little endian"/>
+      <entry name="xvyu16161616" value="0x38345658" summary="[63:0] X:Cr:Y:Cb 16:16:16:16 little endian"/>
+      <entry name="y0l0" value="0x304c3059" summary="[63:0]   A3:A2:Y3:0:Cr0:0:Y2:0:A1:A0:Y1:0:Cb0:0:Y0:0  1:1:8:2:8:2:8:2:1:1:8:2:8:2:8:2 little endian"/>
+      <entry name="x0l0" value="0x304c3058" summary="[63:0]   X3:X2:Y3:0:Cr0:0:Y2:0:X1:X0:Y1:0:Cb0:0:Y0:0  1:1:8:2:8:2:8:2:1:1:8:2:8:2:8:2 little endian"/>
+      <entry name="y0l2" value="0x324c3059" summary="[63:0]   A3:A2:Y3:Cr0:Y2:A1:A0:Y1:Cb0:Y0  1:1:10:10:10:1:1:10:10:10 little endian"/>
+      <entry name="x0l2" value="0x324c3058" summary="[63:0]   X3:X2:Y3:Cr0:Y2:X1:X0:Y1:Cb0:Y0  1:1:10:10:10:1:1:10:10:10 little endian"/>
+      <entry name="yuv420_8bit" value="0x38305559"/>
+      <entry name="yuv420_10bit" value="0x30315559"/>
+      <entry name="xrgb8888_a8" value="0x38415258"/>
+      <entry name="xbgr8888_a8" value="0x38414258"/>
+      <entry name="rgbx8888_a8" value="0x38415852"/>
+      <entry name="bgrx8888_a8" value="0x38415842"/>
+      <entry name="rgb888_a8" value="0x38413852"/>
+      <entry name="bgr888_a8" value="0x38413842"/>
+      <entry name="rgb565_a8" value="0x38413552"/>
+      <entry name="bgr565_a8" value="0x38413542"/>
+      <entry name="nv24" value="0x3432564e" summary="non-subsampled Cr:Cb plane"/>
+      <entry name="nv42" value="0x3234564e" summary="non-subsampled Cb:Cr plane"/>
+      <entry name="p210" value="0x30313250" summary="2x1 subsampled Cr:Cb plane, 10 bit per channel"/>
+      <entry name="p010" value="0x30313050" summary="2x2 subsampled Cr:Cb plane 10 bits per channel"/>
+      <entry name="p012" value="0x32313050" summary="2x2 subsampled Cr:Cb plane 12 bits per channel"/>
+      <entry name="p016" value="0x36313050" summary="2x2 subsampled Cr:Cb plane 16 bits per channel"/>
+      <entry name="axbxgxrx106106106106" value="0x30314241" summary="[63:0] A:x:B:x:G:x:R:x 10:6:10:6:10:6:10:6 little endian"/>
+      <entry name="nv15" value="0x3531564e" summary="2x2 subsampled Cr:Cb plane"/>
+      <entry name="q410" value="0x30313451"/>
+      <entry name="q401" value="0x31303451"/>
+      <entry name="xrgb16161616" value="0x38345258" summary="[63:0] x:R:G:B 16:16:16:16 little endian"/>
+      <entry name="xbgr16161616" value="0x38344258" summary="[63:0] x:B:G:R 16:16:16:16 little endian"/>
+      <entry name="argb16161616" value="0x38345241" summary="[63:0] A:R:G:B 16:16:16:16 little endian"/>
+      <entry name="abgr16161616" value="0x38344241" summary="[63:0] A:B:G:R 16:16:16:16 little endian"/>
+      <entry name="c1" value="0x20203143" summary="[7:0] C0:C1:C2:C3:C4:C5:C6:C7 1:1:1:1:1:1:1:1 eight pixels/byte"/>
+      <entry name="c2" value="0x20203243" summary="[7:0] C0:C1:C2:C3 2:2:2:2 four pixels/byte"/>
+      <entry name="c4" value="0x20203443" summary="[7:0] C0:C1 4:4 two pixels/byte"/>
+      <entry name="d1" value="0x20203144" summary="[7:0] D0:D1:D2:D3:D4:D5:D6:D7 1:1:1:1:1:1:1:1 eight pixels/byte"/>
+      <entry name="d2" value="0x20203244" summary="[7:0] D0:D1:D2:D3 2:2:2:2 four pixels/byte"/>
+      <entry name="d4" value="0x20203444" summary="[7:0] D0:D1 4:4 two pixels/byte"/>
+      <entry name="d8" value="0x20203844" summary="[7:0] D"/>
+      <entry name="r1" value="0x20203152" summary="[7:0] R0:R1:R2:R3:R4:R5:R6:R7 1:1:1:1:1:1:1:1 eight pixels/byte"/>
+      <entry name="r2" value="0x20203252" summary="[7:0] R0:R1:R2:R3 2:2:2:2 four pixels/byte"/>
+      <entry name="r4" value="0x20203452" summary="[7:0] R0:R1 4:4 two pixels/byte"/>
+      <entry name="r10" value="0x20303152" summary="[15:0] x:R 6:10 little endian"/>
+      <entry name="r12" value="0x20323152" summary="[15:0] x:R 4:12 little endian"/>
+      <entry name="avuy8888" value="0x59555641" summary="[31:0] A:Cr:Cb:Y 8:8:8:8 little endian"/>
+      <entry name="xvuy8888" value="0x59555658" summary="[31:0] X:Cr:Cb:Y 8:8:8:8 little endian"/>
+      <entry name="p030" value="0x30333050" summary="2x2 subsampled Cr:Cb plane 10 bits per channel packed"/>
     </enum>
 
     <request name="create_pool">
@@ -352,12 +442,11 @@
 
 	The pool can be used to create shared memory based buffer
 	objects.  The server will mmap size bytes of the passed file
-        descriptor, to use as backing memory for the pool.
+	descriptor, to use as backing memory for the pool.
       </description>
-
-      <arg name="id" type="new_id" interface="wl_shm_pool"/>
-      <arg name="fd" type="fd"/>
-      <arg name="size" type="int"/>
+      <arg name="id" type="new_id" interface="wl_shm_pool" summary="pool to create"/>
+      <arg name="fd" type="fd" summary="file descriptor for the pool"/>
+      <arg name="size" type="int" summary="pool size, in bytes"/>
     </request>
 
     <event name="format">
@@ -366,17 +455,38 @@
 	can be used for buffers. Known formats include
 	argb8888 and xrgb8888.
       </description>
-      <arg name="format" type="uint"/>
+      <arg name="format" type="uint" enum="format" summary="buffer pixel format"/>
     </event>
+
+    <!-- Version 2 additions -->
+
+    <request name="release" type="destructor" since="2">
+      <description summary="release the shm object">
+	Using this request a client can tell the server that it is not going to
+	use the shm object anymore.
+
+	Objects created via this interface remain unaffected.
+      </description>
+    </request>
   </interface>
 
   <interface name="wl_buffer" version="1">
     <description summary="content for a wl_surface">
       A buffer provides the content for a wl_surface. Buffers are
-      created through factory interfaces such as wl_drm, wl_shm or
-      similar. It has a width and a height and can be attached to a
-      wl_surface, but the mechanism by which a client provides and
-      updates the contents is defined by the buffer factory interface.
+      created through factory interfaces such as wl_shm, wp_linux_buffer_params
+      (from the linux-dmabuf protocol extension) or similar. It has a width and
+      a height and can be attached to a wl_surface, but the mechanism by which a
+      client provides and updates the contents is defined by the buffer factory
+      interface.
+
+      Color channels are assumed to be electrical rather than optical (in other
+      words, encoded with a transfer function) unless otherwise specified. If
+      the buffer uses a format that has an alpha channel, the alpha channel is
+      assumed to be premultiplied into the electrical color channel values
+      (after transfer function encoding) unless otherwise specified.
+
+      Note, because wl_buffer objects are created from multiple independent
+      factory interfaces, the wl_buffer interface is frozen at version 1.
     </description>
 
     <request name="destroy" type="destructor">
@@ -391,13 +501,15 @@
     <event name="release">
       <description summary="compositor releases buffer">
 	Sent when this wl_buffer is no longer used by the compositor.
-	The client is now free to re-use or destroy this buffer and its
-	backing storage.
+
+	For more information on when release events may or may not be sent,
+	and what consequences it has, please see the description of
+	wl_surface.attach.
 
 	If a client receives a release event before the frame callback
 	requested in the same wl_surface.commit that attaches this
 	wl_buffer to a surface, then the client is immediately free to
-	re-use the buffer and its backing storage, and does not need a
+	reuse the buffer and its backing storage, and does not need a
 	second buffer for the next surface content update. Typically
 	this is possible, when the compositor maintains a copy of the
 	wl_surface contents, e.g. as a GL texture. This is an important
@@ -406,8 +518,7 @@
     </event>
   </interface>
 
-
-  <interface name="wl_data_offer" version="1">
+  <interface name="wl_data_offer" version="3">
     <description summary="offer to transfer data">
       A wl_data_offer represents a piece of data offered for transfer
       by another client (the source client).  It is used by the
@@ -417,16 +528,36 @@
       data directly from the source client.
     </description>
 
+    <enum name="error">
+      <entry name="invalid_finish" value="0"
+	     summary="finish request was called untimely"/>
+      <entry name="invalid_action_mask" value="1"
+	     summary="action mask contains invalid values"/>
+      <entry name="invalid_action" value="2"
+	     summary="action argument has an invalid value"/>
+      <entry name="invalid_offer" value="3"
+	     summary="offer doesn't accept this request"/>
+    </enum>
+
     <request name="accept">
       <description summary="accept one of the offered mime types">
 	Indicate that the client can accept the given mime type, or
 	NULL for not accepted.
 
-	Used for feedback during drag-and-drop.
-      </description>
+	For objects of version 2 or older, this request is used by the
+	client to give feedback whether the client can receive the given
+	mime type, or NULL if none is accepted; the feedback does not
+	determine whether the drag-and-drop operation succeeds or not.
 
-      <arg name="serial" type="uint"/>
-      <arg name="mime_type" type="string" allow-null="true"/>
+	For objects of version 3 or newer, this request determines the
+	final result of the drag-and-drop operation. If the end result
+	is that no mime types were accepted, the drag-and-drop operation
+	will be cancelled and the corresponding drag source will receive
+	wl_data_source.cancelled. Clients may still use this event in
+	conjunction with wl_data_source.action for feedback.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the accept request"/>
+      <arg name="mime_type" type="string" allow-null="true" summary="mime type accepted by the client"/>
     </request>
 
     <request name="receive">
@@ -439,11 +570,16 @@
 	file descriptor.
 
 	The receiving client reads from the read end of the pipe until
-	EOF and the closes its end, at which point the transfer is
+	EOF and then closes its end, at which point the transfer is
 	complete.
+
+	This request may happen multiple times for different mime types,
+	both before and after wl_data_device.drop. Drag-and-drop destination
+	clients may preemptively fetch data or examine it more closely to
+	determine acceptance.
       </description>
-      <arg name="mime_type" type="string"/>
-      <arg name="fd" type="fd"/>
+      <arg name="mime_type" type="string" summary="mime type desired by receiver"/>
+      <arg name="fd" type="fd" summary="file descriptor for data transfer"/>
     </request>
 
     <request name="destroy" type="destructor">
@@ -457,12 +593,125 @@
 	Sent immediately after creating the wl_data_offer object.  One
 	event per offered mime type.
       </description>
+      <arg name="mime_type" type="string" summary="offered mime type"/>
+    </event>
 
-      <arg name="mime_type" type="string"/>
+    <!-- Version 3 additions -->
+
+    <request name="finish" since="3">
+      <description summary="the offer will no longer be used">
+	Notifies the compositor that the drag destination successfully
+	finished the drag-and-drop operation.
+
+	Upon receiving this request, the compositor will emit
+	wl_data_source.dnd_finished on the drag source client.
+
+	It is a client error to perform other requests than
+	wl_data_offer.destroy after this one. It is also an error to perform
+	this request after a NULL mime type has been set in
+	wl_data_offer.accept or no action was received through
+	wl_data_offer.action.
+
+	If wl_data_offer.finish request is received for a non drag and drop
+	operation, the invalid_finish protocol error is raised.
+      </description>
+    </request>
+
+    <request name="set_actions" since="3">
+      <description summary="set the available/preferred drag-and-drop actions">
+	Sets the actions that the destination side client supports for
+	this operation. This request may trigger the emission of
+	wl_data_source.action and wl_data_offer.action events if the compositor
+	needs to change the selected action.
+
+	This request can be called multiple times throughout the
+	drag-and-drop operation, typically in response to wl_data_device.enter
+	or wl_data_device.motion events.
+
+	This request determines the final result of the drag-and-drop
+	operation. If the end result is that no action is accepted,
+	the drag source will receive wl_data_source.cancelled.
+
+	The dnd_actions argument must contain only values expressed in the
+	wl_data_device_manager.dnd_actions enum, and the preferred_action
+	argument must only contain one of those values set, otherwise it
+	will result in a protocol error.
+
+	While managing an "ask" action, the destination drag-and-drop client
+	may perform further wl_data_offer.receive requests, and is expected
+	to perform one last wl_data_offer.set_actions request with a preferred
+	action other than "ask" (and optionally wl_data_offer.accept) before
+	requesting wl_data_offer.finish, in order to convey the action selected
+	by the user. If the preferred action is not in the
+	wl_data_offer.source_actions mask, an error will be raised.
+
+	If the "ask" action is dismissed (e.g. user cancellation), the client
+	is expected to perform wl_data_offer.destroy right away.
+
+	This request can only be made on drag-and-drop offers, a protocol error
+	will be raised otherwise.
+      </description>
+      <arg name="dnd_actions" type="uint" summary="actions supported by the destination client"
+	   enum="wl_data_device_manager.dnd_action"/>
+      <arg name="preferred_action" type="uint" summary="action preferred by the destination client"
+	   enum="wl_data_device_manager.dnd_action"/>
+    </request>
+
+    <event name="source_actions" since="3">
+      <description summary="notify the source-side available actions">
+	This event indicates the actions offered by the data source. It
+	will be sent immediately after creating the wl_data_offer object,
+	or anytime the source side changes its offered actions through
+	wl_data_source.set_actions.
+      </description>
+      <arg name="source_actions" type="uint" summary="actions offered by the data source"
+	   enum="wl_data_device_manager.dnd_action"/>
+    </event>
+
+    <event name="action" since="3">
+      <description summary="notify the selected action">
+	This event indicates the action selected by the compositor after
+	matching the source/destination side actions. Only one action (or
+	none) will be offered here.
+
+	This event can be emitted multiple times during the drag-and-drop
+	operation in response to destination side action changes through
+	wl_data_offer.set_actions.
+
+	This event will no longer be emitted after wl_data_device.drop
+	happened on the drag-and-drop destination, the client must
+	honor the last action received, or the last preferred one set
+	through wl_data_offer.set_actions when handling an "ask" action.
+
+	Compositors may also change the selected action on the fly, mainly
+	in response to keyboard modifier changes during the drag-and-drop
+	operation.
+
+	The most recent action received is always the valid one. Prior to
+	receiving wl_data_device.drop, the chosen action may change (e.g.
+	due to keyboard modifiers being pressed). At the time of receiving
+	wl_data_device.drop the drag-and-drop destination must honor the
+	last action received.
+
+	Action changes may still happen after wl_data_device.drop,
+	especially on "ask" actions, where the drag-and-drop destination
+	may choose another action afterwards. Action changes happening
+	at this stage are always the result of inter-client negotiation, the
+	compositor shall no longer be able to induce a different action.
+
+	Upon "ask" actions, it is expected that the drag-and-drop destination
+	may potentially choose a different action and/or mime type,
+	based on wl_data_offer.source_actions and finally chosen by the
+	user (e.g. popping up a menu with the available options). The
+	final wl_data_offer.set_actions and wl_data_offer.accept requests
+	must happen before the call to wl_data_offer.finish.
+      </description>
+      <arg name="dnd_action" type="uint" summary="action selected by the compositor"
+	   enum="wl_data_device_manager.dnd_action"/>
     </event>
   </interface>
 
-  <interface name="wl_data_source" version="1">
+  <interface name="wl_data_source" version="3">
     <description summary="offer to transfer data">
       The wl_data_source object is the source side of a wl_data_offer.
       It is created by the source client in a data transfer and
@@ -470,13 +719,20 @@
       to requests to transfer the data.
     </description>
 
+    <enum name="error">
+      <entry name="invalid_action_mask" value="0"
+	     summary="action mask contains invalid values"/>
+      <entry name="invalid_source" value="1"
+	     summary="source doesn't accept this request"/>
+    </enum>
+
     <request name="offer">
       <description summary="add an offered mime type">
 	This request adds a mime type to the set of mime types
 	advertised to targets.  Can be called several times to offer
 	multiple types.
       </description>
-      <arg name="mime_type" type="string"/>
+      <arg name="mime_type" type="string" summary="mime type offered by the data source"/>
     </request>
 
     <request name="destroy" type="destructor">
@@ -492,8 +748,7 @@
 
 	Used for feedback during drag-and-drop.
       </description>
-
-      <arg name="mime_type" type="string" allow-null="true"/>
+      <arg name="mime_type" type="string" allow-null="true" summary="mime type accepted by the target"/>
     </event>
 
     <event name="send">
@@ -502,21 +757,116 @@
 	specified mime type over the passed file descriptor, then
 	close it.
       </description>
-
-      <arg name="mime_type" type="string"/>
-      <arg name="fd" type="fd"/>
+      <arg name="mime_type" type="string" summary="mime type for the data"/>
+      <arg name="fd" type="fd" summary="file descriptor for the data"/>
     </event>
 
     <event name="cancelled">
       <description summary="selection was cancelled">
-	This data source has been replaced by another data source.
+	This data source is no longer valid. There are several reasons why
+	this could happen:
+
+	- The data source has been replaced by another data source.
+	- The drag-and-drop operation was performed, but the drop destination
+	  did not accept any of the mime types offered through
+	  wl_data_source.target.
+	- The drag-and-drop operation was performed, but the drop destination
+	  did not select any of the actions present in the mask offered through
+	  wl_data_source.action.
+	- The drag-and-drop operation was performed but didn't happen over a
+	  surface.
+	- The compositor cancelled the drag-and-drop operation (e.g. compositor
+	  dependent timeouts to avoid stale drag-and-drop transfers).
+
 	The client should clean up and destroy this data source.
+
+	For objects of version 2 or older, wl_data_source.cancelled will
+	only be emitted if the data source was replaced by another data
+	source.
       </description>
     </event>
 
+    <!-- Version 3 additions -->
+
+    <request name="set_actions" since="3">
+      <description summary="set the available drag-and-drop actions">
+	Sets the actions that the source side client supports for this
+	operation. This request may trigger wl_data_source.action and
+	wl_data_offer.action events if the compositor needs to change the
+	selected action.
+
+	The dnd_actions argument must contain only values expressed in the
+	wl_data_device_manager.dnd_actions enum, otherwise it will result
+	in a protocol error.
+
+	This request must be made once only, and can only be made on sources
+	used in drag-and-drop, so it must be performed before
+	wl_data_device.start_drag. Attempting to use the source other than
+	for drag-and-drop will raise a protocol error.
+      </description>
+      <arg name="dnd_actions" type="uint" summary="actions supported by the data source"
+	   enum="wl_data_device_manager.dnd_action"/>
+    </request>
+
+    <event name="dnd_drop_performed" since="3">
+      <description summary="the drag-and-drop operation physically finished">
+	The user performed the drop action. This event does not indicate
+	acceptance, wl_data_source.cancelled may still be emitted afterwards
+	if the drop destination does not accept any mime type.
+
+	However, this event might however not be received if the compositor
+	cancelled the drag-and-drop operation before this event could happen.
+
+	Note that the data_source may still be used in the future and should
+	not be destroyed here.
+      </description>
+    </event>
+
+    <event name="dnd_finished" since="3">
+      <description summary="the drag-and-drop operation concluded">
+	The drop destination finished interoperating with this data
+	source, so the client is now free to destroy this data source and
+	free all associated data.
+
+	If the action used to perform the operation was "move", the
+	source can now delete the transferred data.
+      </description>
+    </event>
+
+    <event name="action" since="3">
+      <description summary="notify the selected action">
+	This event indicates the action selected by the compositor after
+	matching the source/destination side actions. Only one action (or
+	none) will be offered here.
+
+	This event can be emitted multiple times during the drag-and-drop
+	operation, mainly in response to destination side changes through
+	wl_data_offer.set_actions, and as the data device enters/leaves
+	surfaces.
+
+	It is only possible to receive this event after
+	wl_data_source.dnd_drop_performed if the drag-and-drop operation
+	ended in an "ask" action, in which case the final wl_data_source.action
+	event will happen immediately before wl_data_source.dnd_finished.
+
+	Compositors may also change the selected action on the fly, mainly
+	in response to keyboard modifier changes during the drag-and-drop
+	operation.
+
+	The most recent action received is always the valid one. The chosen
+	action may change alongside negotiation (e.g. an "ask" action can turn
+	into a "move" operation), so the effects of the final action must
+	always be applied in wl_data_offer.dnd_finished.
+
+	Clients can trigger cursor surface changes from this point, so
+	they reflect the current action.
+      </description>
+      <arg name="dnd_action" type="uint" summary="action selected by the compositor"
+	   enum="wl_data_device_manager.dnd_action"/>
+    </event>
   </interface>
 
-  <interface name="wl_data_device" version="1">
+  <interface name="wl_data_device" version="3">
     <description summary="data transfer device">
       There is one wl_data_device per seat which can be obtained
       from the global wl_data_device_manager singleton.
@@ -524,6 +874,12 @@
       A wl_data_device provides access to inter-client data transfer
       mechanisms such as copy-and-paste and drag-and-drop.
     </description>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+      <entry name="used_source" value="1" summary="source has already been used"/>
+    </enum>
+
     <request name="start_drag">
       <description summary="start drag-and-drop operation">
 	This request asks the compositor to start a drag-and-drop
@@ -533,7 +889,8 @@
 	for the eventual data transfer. If source is NULL, enter, leave
 	and motion events are sent only to the client that initiated the
 	drag and the client is expected to handle the data passing
-	internally.
+	internally. If source is destroyed, the drag-and-drop session will be
+	cancelled.
 
 	The origin surface is the surface where the drag originates and
 	the client must have an active implicit grab that matches the
@@ -542,20 +899,23 @@
 	The icon surface is an optional (can be NULL) surface that
 	provides an icon to be moved around with the cursor.  Initially,
 	the top-left corner of the icon surface is placed at the cursor
-	hotspot, but subsequent wl_surface.attach request can move the
+	hotspot, but subsequent wl_surface.offset requests can move the
 	relative position. Attach requests must be confirmed with
-	wl_surface.commit as usual.
+	wl_surface.commit as usual. The icon surface is given the role of
+	a drag-and-drop icon. If the icon surface already has another role,
+	it raises a protocol error.
 
-	The current and pending input regions of the icon wl_surface are
-	cleared, and wl_surface.set_input_region is ignored until the
-	wl_surface is no longer used as the icon surface. When the use
-	as an icon ends, the the current and pending input regions
-	become undefined, and the wl_surface is unmapped.
+	The input region is ignored for wl_surfaces with the role of a
+	drag-and-drop icon.
+
+	The given source may not be used in any further set_selection or
+	start_drag requests. Attempting to reuse a previously-used source
+	may send a used_source error.
       </description>
-      <arg name="source" type="object" interface="wl_data_source" allow-null="true"/>
-      <arg name="origin" type="object" interface="wl_surface"/>
-      <arg name="icon" type="object" interface="wl_surface" allow-null="true"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the origin"/>
+      <arg name="source" type="object" interface="wl_data_source" allow-null="true" summary="data source for the eventual transfer"/>
+      <arg name="origin" type="object" interface="wl_surface" summary="surface where the drag originates"/>
+      <arg name="icon" type="object" interface="wl_surface" allow-null="true" summary="drag-and-drop icon surface"/>
+      <arg name="serial" type="uint" summary="serial number of the implicit grab on the origin"/>
     </request>
 
     <request name="set_selection">
@@ -564,9 +924,13 @@
 	to the data from the source on behalf of the client.
 
 	To unset the selection, set the source to NULL.
+
+	The given source may not be used in any further set_selection or
+	start_drag requests. Attempting to reuse a previously-used source
+	may send a used_source error.
       </description>
-      <arg name="source" type="object" interface="wl_data_source" allow-null="true"/>
-      <arg name="serial" type="uint" summary="serial of the event that triggered this request"/>
+      <arg name="source" type="object" interface="wl_data_source" allow-null="true" summary="data source for the selection"/>
+      <arg name="serial" type="uint" summary="serial number of the event that triggered this request"/>
     </request>
 
     <event name="data_offer">
@@ -575,27 +939,26 @@
 	which will subsequently be used in either the
 	data_device.enter event (for drag-and-drop) or the
 	data_device.selection event (for selections).  Immediately
-	following the data_device_data_offer event, the new data_offer
+	following the data_device.data_offer event, the new data_offer
 	object will send out data_offer.offer events to describe the
 	mime types it offers.
       </description>
-
-      <arg name="id" type="new_id" interface="wl_data_offer"/>
+      <arg name="id" type="new_id" interface="wl_data_offer" summary="the new data_offer object"/>
     </event>
 
     <event name="enter">
       <description summary="initiate drag-and-drop session">
 	This event is sent when an active drag-and-drop pointer enters
 	a surface owned by the client.  The position of the pointer at
-	enter time is provided by the x and y arguments, in surface
-	local coordinates.
+	enter time is provided by the x and y arguments, in surface-local
+	coordinates.
       </description>
-
-      <arg name="serial" type="uint"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
-      <arg name="x" type="fixed"/>
-      <arg name="y" type="fixed"/>
-      <arg name="id" type="object" interface="wl_data_offer" allow-null="true"/>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="client surface entered"/>
+      <arg name="x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="y" type="fixed" summary="surface-local y coordinate"/>
+      <arg name="id" type="object" interface="wl_data_offer" allow-null="true"
+	   summary="source data_offer object"/>
     </event>
 
     <event name="leave">
@@ -610,18 +973,29 @@
       <description summary="drag-and-drop session motion">
 	This event is sent when the drag-and-drop pointer moves within
 	the currently focused surface. The new position of the pointer
-	is provided by the x and y arguments, in surface local
+	is provided by the x and y arguments, in surface-local
 	coordinates.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
-      <arg name="x" type="fixed"/>
-      <arg name="y" type="fixed"/>
+      <arg name="x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="y" type="fixed" summary="surface-local y coordinate"/>
     </event>
 
     <event name="drop">
-      <description summary="end drag-and-drag session successfully">
+      <description summary="end drag-and-drop session successfully">
 	The event is sent when a drag-and-drop operation is ended
 	because the implicit grab is removed.
+
+	The drag-and-drop destination is expected to honor the last action
+	received through wl_data_offer.action, if the resulting action is
+	"copy" or "move", the destination can still perform
+	wl_data_offer.receive requests, and is expected to end all
+	transfers with a wl_data_offer.finish request.
+
+	If the resulting action is "ask", the action will not be considered
+	final. The drag-and-drop destination is expected to perform one last
+	wl_data_offer.set_actions request, or wl_data_offer.destroy in order
+	to cancel the operation.
       </description>
     </event>
 
@@ -635,35 +1009,86 @@
 	immediately before receiving keyboard focus and when a new
 	selection is set while the client has keyboard focus.  The
 	data_offer is valid until a new data_offer or NULL is received
-	or until the client loses keyboard focus.
+	or until the client loses keyboard focus.  Switching surface with
+	keyboard focus within the same client doesn't mean a new selection
+	will be sent.  The client must destroy the previous selection
+	data_offer, if any, upon receiving this event.
       </description>
-      <arg name="id" type="object" interface="wl_data_offer" allow-null="true"/>
+      <arg name="id" type="object" interface="wl_data_offer" allow-null="true"
+	   summary="selection data_offer object"/>
     </event>
+
+    <!-- Version 2 additions -->
+
+    <request name="release" type="destructor" since="2">
+      <description summary="destroy data device">
+	This request destroys the data device.
+      </description>
+    </request>
   </interface>
 
-  <interface name="wl_data_device_manager" version="1">
+  <interface name="wl_data_device_manager" version="3">
     <description summary="data transfer interface">
       The wl_data_device_manager is a singleton global object that
       provides access to inter-client data transfer mechanisms such as
       copy-and-paste and drag-and-drop.  These mechanisms are tied to
       a wl_seat and this interface lets a client get a wl_data_device
       corresponding to a wl_seat.
+
+      Depending on the version bound, the objects created from the bound
+      wl_data_device_manager object will have different requirements for
+      functioning properly. See wl_data_source.set_actions,
+      wl_data_offer.accept and wl_data_offer.finish for details.
     </description>
 
     <request name="create_data_source">
       <description summary="create a new data source">
-        Create a new data source.
+	Create a new data source.
       </description>
-      <arg name="id" type="new_id" interface="wl_data_source"/>
+      <arg name="id" type="new_id" interface="wl_data_source" summary="data source to create"/>
     </request>
 
     <request name="get_data_device">
       <description summary="create a new data device">
-        Create a new data device for a given seat.
+	Create a new data device for a given seat.
       </description>
-      <arg name="id" type="new_id" interface="wl_data_device"/>
-      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="id" type="new_id" interface="wl_data_device" summary="data device to create"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="seat associated with the data device"/>
     </request>
+
+    <!-- Version 3 additions -->
+
+    <enum name="dnd_action" bitfield="true" since="3">
+      <description summary="drag and drop actions">
+	This is a bitmask of the available/preferred actions in a
+	drag-and-drop operation.
+
+	In the compositor, the selected action is a result of matching the
+	actions offered by the source and destination sides.  "action" events
+	with a "none" action will be sent to both source and destination if
+	there is no match. All further checks will effectively happen on
+	(source actions ∩ destination actions).
+
+	In addition, compositors may also pick different actions in
+	reaction to key modifiers being pressed. One common design that
+	is used in major toolkits (and the behavior recommended for
+	compositors) is:
+
+	- If no modifiers are pressed, the first match (in bit order)
+	  will be used.
+	- Pressing Shift selects "move", if enabled in the mask.
+	- Pressing Control selects "copy", if enabled in the mask.
+
+	Behavior beyond that is considered implementation-dependent.
+	Compositors may for example bind other modifiers (like Alt/Meta)
+	or drags initiated with other buttons than BTN_LEFT to specific
+	actions (e.g. "ask").
+      </description>
+      <entry name="none" value="0" summary="no action"/>
+      <entry name="copy" value="1" summary="copy action"/>
+      <entry name="move" value="2" summary="move action"/>
+      <entry name="ask" value="4" summary="ask action"/>
+    </enum>
   </interface>
 
   <interface name="wl_shell" version="1">
@@ -673,21 +1098,30 @@
 
       It allows clients to associate a wl_shell_surface with
       a basic surface.
+
+      Note! This protocol is deprecated and not intended for production use.
+      For desktop-style user interfaces, use xdg_shell. Compositors and clients
+      should not implement this interface.
     </description>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+    </enum>
 
     <request name="get_shell_surface">
       <description summary="create a shell surface from a surface">
-	Create a shell surface for an existing surface.
+	Create a shell surface for an existing surface. This gives
+	the wl_surface the role of a shell surface. If the wl_surface
+	already has another role, it raises a protocol error.
 
 	Only one shell surface can be associated with a given surface.
       </description>
-      <arg name="id" type="new_id" interface="wl_shell_surface"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="id" type="new_id" interface="wl_shell_surface" summary="shell surface to create"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface to be given the shell surface role"/>
     </request>
   </interface>
 
   <interface name="wl_shell_surface" version="1">
-
     <description summary="desktop-style metadata interface">
       An interface that may be implemented by a wl_surface, for
       implementations that provide a desktop-style user interface.
@@ -697,7 +1131,7 @@
       metadata like title and class, etc.
 
       On the server side the object is automatically destroyed when
-      the related wl_surface is destroyed.  On client side,
+      the related wl_surface is destroyed. On the client side,
       wl_shell_surface_destroy() must be called before destroying
       the wl_surface object.
     </description>
@@ -707,7 +1141,7 @@
 	A client must respond to a ping event with a pong request or
 	the client may be deemed unresponsive.
       </description>
-      <arg name="serial" type="uint" summary="serial of the ping event"/>
+      <arg name="serial" type="uint" summary="serial number of the ping event"/>
     </request>
 
     <request name="move">
@@ -718,26 +1152,26 @@
 	The server may ignore move requests depending on the state of
 	the surface (e.g. fullscreen or maximized).
       </description>
-      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat whose pointer is used"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="seat whose pointer is used"/>
+      <arg name="serial" type="uint" summary="serial number of the implicit grab on the pointer"/>
     </request>
 
-    <enum name="resize">
+    <enum name="resize" bitfield="true">
       <description summary="edge values for resizing">
 	These values are used to indicate which edge of a surface
 	is being dragged in a resize operation. The server may
 	use this information to adapt its behavior, e.g. choose
 	an appropriate cursor image.
       </description>
-      <entry name="none" value="0"/>
-      <entry name="top" value="1"/>
-      <entry name="bottom" value="2"/>
-      <entry name="left" value="4"/>
-      <entry name="top_left" value="5"/>
-      <entry name="bottom_left" value="6"/>
-      <entry name="right" value="8"/>
-      <entry name="top_right" value="9"/>
-      <entry name="bottom_right" value="10"/>
+      <entry name="none" value="0" summary="no edge"/>
+      <entry name="top" value="1" summary="top edge"/>
+      <entry name="bottom" value="2" summary="bottom edge"/>
+      <entry name="left" value="4" summary="left edge"/>
+      <entry name="top_left" value="5" summary="top and left edges"/>
+      <entry name="bottom_left" value="6" summary="bottom and left edges"/>
+      <entry name="right" value="8" summary="right edge"/>
+      <entry name="top_right" value="9" summary="top and right edges"/>
+      <entry name="bottom_right" value="10" summary="bottom and right edges"/>
     </enum>
 
     <request name="resize">
@@ -748,9 +1182,9 @@
 	The server may ignore resize requests depending on the state of
 	the surface (e.g. fullscreen or maximized).
       </description>
-      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat whose pointer is used"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
-      <arg name="edges" type="uint" summary="which edge or corner is being dragged"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="seat whose pointer is used"/>
+      <arg name="serial" type="uint" summary="serial number of the implicit grab on the pointer"/>
+      <arg name="edges" type="uint" enum="resize" summary="which edge or corner is being dragged"/>
     </request>
 
     <request name="set_toplevel">
@@ -761,7 +1195,7 @@
       </description>
     </request>
 
-    <enum name="transient">
+    <enum name="transient" bitfield="true">
       <description summary="details of transient behaviour">
 	These flags specify details of the expected behaviour
 	of transient surfaces. Used in the set_transient request.
@@ -773,17 +1207,16 @@
       <description summary="make the surface a transient surface">
 	Map the surface relative to an existing surface.
 
-	The x and y arguments specify the locations of the upper left
+	The x and y arguments specify the location of the upper left
 	corner of the surface relative to the upper left corner of the
-	parent surface, in surface local coordinates.
+	parent surface, in surface-local coordinates.
 
 	The flags argument controls details of the transient behaviour.
       </description>
-
-      <arg name="parent" type="object" interface="wl_surface"/>
-      <arg name="x" type="int"/>
-      <arg name="y" type="int"/>
-      <arg name="flags" type="uint"/>
+      <arg name="parent" type="object" interface="wl_surface" summary="parent surface"/>
+      <arg name="x" type="int" summary="surface-local x coordinate"/>
+      <arg name="y" type="int" summary="surface-local y coordinate"/>
+      <arg name="flags" type="uint" enum="transient" summary="transient surface behavior"/>
     </request>
 
     <enum name="fullscreen_method">
@@ -814,7 +1247,7 @@
 
 	The framerate parameter is used only when the method is set
 	to "driver", to indicate the preferred framerate. A value of 0
-	indicates that the app does not care about framerate.  The
+	indicates that the client does not care about framerate.  The
 	framerate is specified in mHz, that is framerate of 60000 is 60Hz.
 
 	A method of "scale" or "driver" implies a scaling operation of
@@ -834,9 +1267,10 @@
 	with the dimensions for the output on which the surface will
 	be made fullscreen.
       </description>
-      <arg name="method" type="uint"/>
-      <arg name="framerate" type="uint"/>
-      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="method" type="uint" enum="fullscreen_method" summary="method for resolving size conflict"/>
+      <arg name="framerate" type="uint" summary="framerate in mHz"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"
+	   summary="output on which the surface is to be fullscreen"/>
     </request>
 
     <request name="set_popup">
@@ -852,22 +1286,21 @@
 	be unmapped).
 
 	The popup grab continues until the window is destroyed or a
-	mouse button is pressed in any other clients window. A click
-	in any of the clients surfaces is reported as normal, however,
-	clicks in other clients surfaces will be discarded and trigger
+	mouse button is pressed in any other client's window. A click
+	in any of the client's surfaces is reported as normal, however,
+	clicks in other clients' surfaces will be discarded and trigger
 	the callback.
 
-	The x and y arguments specify the locations of the upper left
+	The x and y arguments specify the location of the upper left
 	corner of the surface relative to the upper left corner of the
-	parent surface, in surface local coordinates.
+	parent surface, in surface-local coordinates.
       </description>
-
-      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat whose pointer is used"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
-      <arg name="parent" type="object" interface="wl_surface"/>
-      <arg name="x" type="int"/>
-      <arg name="y" type="int"/>
-      <arg name="flags" type="uint"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="seat whose pointer is used"/>
+      <arg name="serial" type="uint" summary="serial number of the implicit grab on the pointer"/>
+      <arg name="parent" type="object" interface="wl_surface" summary="parent surface"/>
+      <arg name="x" type="int" summary="surface-local x coordinate"/>
+      <arg name="y" type="int" summary="surface-local y coordinate"/>
+      <arg name="flags" type="uint" enum="transient" summary="transient surface behavior"/>
     </request>
 
     <request name="set_maximized">
@@ -885,13 +1318,14 @@
 	on the next buffer attach to this surface.
 
 	A maximized surface typically fills the entire output it is
-	bound to, except for desktop element such as panels. This is
+	bound to, except for desktop elements such as panels. This is
 	the main difference between a maximized shell surface and a
 	fullscreen shell surface.
 
 	The details depend on the compositor implementation.
       </description>
-      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"
+	   summary="output on which the surface is to be maximized"/>
     </request>
 
     <request name="set_title">
@@ -904,7 +1338,7 @@
 
 	The string must be encoded in UTF-8.
       </description>
-      <arg name="title" type="string"/>
+      <arg name="title" type="string" summary="surface title"/>
     </request>
 
     <request name="set_class">
@@ -916,7 +1350,7 @@
 	file name (or the full path if it is a non-standard location) of
 	the application's .desktop file as the class.
       </description>
-      <arg name="class_" type="string"/>
+      <arg name="class_" type="string" summary="surface class"/>
     </request>
 
     <event name="ping">
@@ -924,7 +1358,7 @@
 	Ping a client to check if it is receiving events and sending
 	requests. A client is expected to reply with a pong request.
       </description>
-      <arg name="serial" type="uint"/>
+      <arg name="serial" type="uint" summary="serial number of the ping"/>
     </event>
 
     <event name="configure">
@@ -945,12 +1379,11 @@
 	event it received.
 
 	The width and height arguments specify the size of the window
-	in surface local coordinates.
+	in surface-local coordinates.
       </description>
-
-      <arg name="edges" type="uint"/>
-      <arg name="width" type="int"/>
-      <arg name="height" type="int"/>
+      <arg name="edges" type="uint" enum="resize" summary="how the surface was resized"/>
+      <arg name="width" type="int" summary="new width of the surface"/>
+      <arg name="height" type="int" summary="new height of the surface"/>
     </event>
 
     <event name="popup_done">
@@ -962,19 +1395,63 @@
     </event>
   </interface>
 
-  <interface name="wl_surface" version="3">
+  <interface name="wl_surface" version="6">
     <description summary="an onscreen surface">
-      A surface is a rectangular area that is displayed on the screen.
-      It has a location, size and pixel contents.
+      A surface is a rectangular area that may be displayed on zero
+      or more outputs, and shown any number of times at the compositor's
+      discretion. They can present wl_buffers, receive user input, and
+      define a local coordinate system.
 
       The size of a surface (and relative positions on it) is described
-      in surface local coordinates, which may differ from the buffer
-      local coordinates of the pixel content, in case a buffer_transform
+      in surface-local coordinates, which may differ from the buffer
+      coordinates of the pixel content, in case a buffer_transform
       or a buffer_scale is used.
 
-      Surfaces are also used for some special purposes, e.g. as
-      cursor images for pointers, drag icons, etc.
+      A surface without a "role" is fairly useless: a compositor does
+      not know where, when or how to present it. The role is the
+      purpose of a wl_surface. Examples of roles are a cursor for a
+      pointer (as set by wl_pointer.set_cursor), a drag icon
+      (wl_data_device.start_drag), a sub-surface
+      (wl_subcompositor.get_subsurface), and a window as defined by a
+      shell protocol (e.g. wl_shell.get_shell_surface).
+
+      A surface can have only one role at a time. Initially a
+      wl_surface does not have a role. Once a wl_surface is given a
+      role, it is set permanently for the whole lifetime of the
+      wl_surface object. Giving the current role again is allowed,
+      unless explicitly forbidden by the relevant interface
+      specification.
+
+      Surface roles are given by requests in other interfaces such as
+      wl_pointer.set_cursor. The request should explicitly mention
+      that this request gives a role to a wl_surface. Often, this
+      request also creates a new protocol object that represents the
+      role and adds additional functionality to wl_surface. When a
+      client wants to destroy a wl_surface, they must destroy this role
+      object before the wl_surface, otherwise a defunct_role_object error is
+      sent.
+
+      Destroying the role object does not remove the role from the
+      wl_surface, but it may stop the wl_surface from "playing the role".
+      For instance, if a wl_subsurface object is destroyed, the wl_surface
+      it was created for will be unmapped and forget its position and
+      z-order. It is allowed to create a wl_subsurface for the same
+      wl_surface again, but it is not allowed to use the wl_surface as
+      a cursor (cursor is a different role than sub-surface, and role
+      switching is not allowed).
     </description>
+
+    <enum name="error">
+      <description summary="wl_surface error values">
+	These errors can be emitted in response to wl_surface requests.
+      </description>
+      <entry name="invalid_scale" value="0" summary="buffer scale value is invalid"/>
+      <entry name="invalid_transform" value="1" summary="buffer transform value is invalid"/>
+      <entry name="invalid_size" value="2" summary="buffer size is invalid"/>
+      <entry name="invalid_offset" value="3" summary="buffer offset is invalid"/>
+      <entry name="defunct_role_object" value="4"
+	     summary="surface was destroyed before its role object"/>
+    </enum>
 
     <request name="destroy" type="destructor">
       <description summary="delete surface">
@@ -988,14 +1465,23 @@
 
 	The new size of the surface is calculated based on the buffer
 	size transformed by the inverse buffer_transform and the
-	inverse buffer_scale. This means that the supplied buffer
-	must be an integer multiple of the buffer_scale.
+	inverse buffer_scale. This means that at commit time the supplied
+	buffer size must be an integer multiple of the buffer_scale. If
+	that's not the case, an invalid_size error is sent.
 
 	The x and y arguments specify the location of the new pending
 	buffer's upper left corner, relative to the current buffer's upper
-	left corner, in surface local coordinates. In other words, the
+	left corner, in surface-local coordinates. In other words, the
 	x and y, combined with the new surface size define in which
-	directions the surface's size changes.
+	directions the surface's size changes. Setting anything other than 0
+	as x and y arguments is discouraged, and should instead be replaced
+	with using the separate wl_surface.offset request.
+
+	When the bound wl_surface version is 5 or higher, passing any
+	non-zero x or y is a protocol violation, and will result in an
+	'invalid_offset' error being raised. The x and y arguments are ignored
+	and do not change the pending state. To achieve equivalent semantics,
+	use wl_surface.offset.
 
 	Surface contents are double-buffered state, see wl_surface.commit.
 
@@ -1011,37 +1497,53 @@
 	any time after the wl_surface.commit request. When the compositor
 	will not access the pixels anymore, it will send the
 	wl_buffer.release event. Only after receiving wl_buffer.release,
-	the client may re-use the wl_buffer. A wl_buffer that has been
+	the client may reuse the wl_buffer. A wl_buffer that has been
 	attached and then replaced by another attach instead of committed
 	will not receive a release event, and is not used by the
 	compositor.
 
+	If a pending wl_buffer has been committed to more than one wl_surface,
+	the delivery of wl_buffer.release events becomes undefined. A well
+	behaved client should not rely on wl_buffer.release events in this
+	case. Alternatively, a client could create multiple wl_buffer objects
+	from the same backing storage or use a protocol extension providing
+	per-commit release notifications.
+
 	Destroying the wl_buffer after wl_buffer.release does not change
-	the surface contents. However, if the client destroys the
-	wl_buffer before receiving the wl_buffer.release event, the surface
-	contents become undefined immediately.
+	the surface contents. Destroying the wl_buffer before wl_buffer.release
+	is allowed as long as the underlying buffer storage isn't re-used (this
+	can happen e.g. on client process termination). However, if the client
+	destroys the wl_buffer before receiving the wl_buffer.release event and
+	mutates the underlying buffer storage, the surface contents become
+	undefined immediately.
 
 	If wl_surface.attach is sent with a NULL wl_buffer, the
 	following wl_surface.commit will remove the surface content.
-      </description>
 
-      <arg name="buffer" type="object" interface="wl_buffer" allow-null="true"/>
-      <arg name="x" type="int"/>
-      <arg name="y" type="int"/>
+	If a pending wl_buffer has been destroyed, the result is not specified.
+	Many compositors are known to remove the surface content on the following
+	wl_surface.commit, but this behaviour is not universal. Clients seeking to
+	maximise compatibility should not destroy pending buffers and should
+	ensure that they explicitly remove content from surfaces, even after
+	destroying buffers.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer" allow-null="true"
+	   summary="buffer of surface contents"/>
+      <arg name="x" type="int" summary="surface-local x coordinate"/>
+      <arg name="y" type="int" summary="surface-local y coordinate"/>
     </request>
 
     <request name="damage">
       <description summary="mark part of the surface damaged">
 	This request is used to describe the regions where the pending
 	buffer is different from the current surface contents, and where
-	the surface therefore needs to be repainted. The pending buffer
-	must be set by wl_surface.attach before sending damage. The
-	compositor ignores the parts of the damage that fall outside of
-	the surface.
+	the surface therefore needs to be repainted. The compositor
+	ignores the parts of the damage that fall outside of the surface.
 
 	Damage is double-buffered state, see wl_surface.commit.
 
-	The damage rectangle is specified in surface local coordinates.
+	The damage rectangle is specified in surface-local coordinates,
+	where x and y specify the upper left corner of the damage rectangle.
 
 	The initial value for pending damage is empty: no damage.
 	wl_surface.damage adds pending damage: the new pending damage
@@ -1050,40 +1552,53 @@
 	wl_surface.commit assigns pending damage as the current damage,
 	and clears pending damage. The server will clear the current
 	damage as it repaints the surface.
-      </description>
 
-      <arg name="x" type="int"/>
-      <arg name="y" type="int"/>
-      <arg name="width" type="int"/>
-      <arg name="height" type="int"/>
+	Note! New clients should not use this request. Instead damage can be
+	posted with wl_surface.damage_buffer which uses buffer coordinates
+	instead of surface coordinates.
+      </description>
+      <arg name="x" type="int" summary="surface-local x coordinate"/>
+      <arg name="y" type="int" summary="surface-local y coordinate"/>
+      <arg name="width" type="int" summary="width of damage rectangle"/>
+      <arg name="height" type="int" summary="height of damage rectangle"/>
     </request>
 
     <request name="frame">
-      <description summary="request repaint feedback">
-	Request notification when the next frame is displayed. Useful
-	for throttling redrawing operations, and driving animations.
+      <description summary="request a frame throttling hint">
+	Request a notification when it is a good time to start drawing a new
+	frame, by creating a frame callback. This is useful for throttling
+	redrawing operations, and driving animations.
+
+	When a client is animating on a wl_surface, it can use the 'frame'
+	request to get notified when it is a good time to draw and commit the
+	next frame of animation. If the client commits an update earlier than
+	that, it is likely that some updates will not make it to the display,
+	and the client is wasting resources by drawing too often.
+
 	The frame request will take effect on the next wl_surface.commit.
 	The notification will only be posted for one frame unless
-	requested again.
+	requested again. For a wl_surface, the notifications are posted in
+	the order the frame requests were committed.
 
-	A server should avoid signalling the frame callbacks if the
+	The server must send the notifications so that a client
+	will not send excessive updates, while still allowing
+	the highest possible update rate for clients that wait for the reply
+	before drawing again. The server should give some time for the client
+	to draw and commit after sending the frame callback events to let it
+	hit the next output refresh.
+
+	A server should avoid signaling the frame callbacks if the
 	surface is not visible in any way, e.g. the surface is off-screen,
 	or completely obscured by other opaque surfaces.
-
-	A client can request a frame callback even without an attach,
-	damage, or any other state changes. wl_surface.commit triggers a
-	display update, so the callback event will arrive after the next
-	output refresh where the surface is visible.
 
 	The object returned by this request will be destroyed by the
 	compositor after the callback is fired and as such the client must not
 	attempt to use it after that point.
 
 	The callback_data passed in the callback is the current time, in
-	milliseconds.
+	milliseconds, with an undefined base.
       </description>
-
-      <arg name="callback" type="new_id" interface="wl_callback"/>
+      <arg name="callback" type="new_id" interface="wl_callback" summary="callback object for the frame request"/>
     </request>
 
     <request name="set_opaque_region">
@@ -1092,12 +1607,12 @@
 	opaque content.
 
 	The opaque region is an optimization hint for the compositor
-	that lets it optimize out redrawing of content behind opaque
+	that lets it optimize the redrawing of content behind opaque
 	regions.  Setting an opaque region is not required for correct
 	behaviour, but marking transparent content as opaque will result
 	in repaint artifacts.
 
-	The opaque region is specified in surface local coordinates.
+	The opaque region is specified in surface-local coordinates.
 
 	The compositor ignores the parts of the opaque region that fall
 	outside of the surface.
@@ -1108,13 +1623,13 @@
 	wl_surface.commit copies the pending region to the current region.
 	Otherwise, the pending and current regions are never changed.
 
-	The initial value for opaque region is empty. Setting the pending
+	The initial value for an opaque region is empty. Setting the pending
 	opaque region has copy semantics, and the wl_region object can be
 	destroyed immediately. A NULL wl_region causes the pending opaque
 	region to be set to empty.
       </description>
-
-      <arg name="region" type="object" interface="wl_region" allow-null="true"/>
+      <arg name="region" type="object" interface="wl_region" allow-null="true"
+	   summary="opaque region of the surface"/>
     </request>
 
     <request name="set_input_region">
@@ -1126,7 +1641,7 @@
 	surface in the server surface stack. The compositor ignores the
 	parts of the input region that fall outside of the surface.
 
-	The input region is specified in surface local coordinates.
+	The input region is specified in surface-local coordinates.
 
 	Input region is double-buffered state, see wl_surface.commit.
 
@@ -1136,30 +1651,32 @@
 	except cursor and icon surfaces are special cases, see
 	wl_pointer.set_cursor and wl_data_device.start_drag.
 
-	The initial value for input region is infinite. That means the
+	The initial value for an input region is infinite. That means the
 	whole surface will accept input. Setting the pending input region
 	has copy semantics, and the wl_region object can be destroyed
 	immediately. A NULL wl_region causes the input region to be set
 	to infinite.
       </description>
-
-      <arg name="region" type="object" interface="wl_region" allow-null="true"/>
+      <arg name="region" type="object" interface="wl_region" allow-null="true"
+	   summary="input region of the surface"/>
     </request>
 
     <request name="commit">
       <description summary="commit pending surface state">
 	Surface state (input, opaque, and damage regions, attached buffers,
-	etc.) is double-buffered. Protocol requests modify the pending
-	state, as opposed to current state in use by the compositor. Commit
-	request atomically applies all pending state, replacing the current
-	state. After commit, the new pending state is as documented for each
-	related request.
+	etc.) is double-buffered. Protocol requests modify the pending state,
+	as opposed to the active state in use by the compositor.
 
-	On commit, a pending wl_buffer is applied first, all other state
-	second. This means that all coordinates in double-buffered state are
-	relative to the new wl_buffer coming into use, except for
-	wl_surface.attach itself. If there is no pending wl_buffer, the
-	coordinates are relative to the current surface contents.
+	A commit request atomically creates a content update from the pending
+	state, even if the pending state has not been touched. The content
+	update is placed in a queue until it becomes active. After commit, the
+	new pending state is as documented for each related request.
+
+	When the content update is applied, the wl_buffer is applied before all
+	other state. This means that all coordinates in double-buffered state
+	are relative to the newly attached wl_buffers, except for
+	wl_surface.attach itself. If there is no newly attached wl_buffer, the
+	coordinates are relative to the previous content update.
 
 	All requests that need a commit to become effective are documented
 	to affect double-buffered state.
@@ -1176,7 +1693,7 @@
 
 	Note that a surface may be overlapping with zero or more outputs.
       </description>
-      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="output" type="object" interface="wl_output" summary="output entered by the surface"/>
     </event>
 
     <event name="leave">
@@ -1184,25 +1701,38 @@
 	This is emitted whenever a surface's creation, movement, or resizing
 	results in it no longer having any part of it within the scanout region
 	of an output.
+
+	Clients should not use the number of outputs the surface is on for frame
+	throttling purposes. The surface might be hidden even if no leave event
+	has been sent, and the compositor might expect new surface content
+	updates even if no enter event has been sent. The frame event should be
+	used instead.
       </description>
-      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="output" type="object" interface="wl_output" summary="output left by the surface"/>
     </event>
 
     <!-- Version 2 additions -->
 
     <request name="set_buffer_transform" since="2">
       <description summary="sets the buffer transformation">
-	This request sets an optional transformation on how the compositor
-	interprets the contents of the buffer attached to the surface. The
-	accepted values for the transform parameter are the values for
-	wl_output.transform.
+	This request sets the transformation that the client has already applied
+	to the content of the buffer. The accepted values for the transform
+	parameter are the values for wl_output.transform.
+
+	The compositor applies the inverse of this transformation whenever it
+	uses the buffer contents.
 
 	Buffer transform is double-buffered state, see wl_surface.commit.
 
 	A newly created surface has its buffer transformation set to normal.
 
+	wl_surface.set_buffer_transform changes the pending buffer
+	transformation. wl_surface.commit copies the pending buffer
+	transformation to the current one. Otherwise, the pending and current
+	values are never changed.
+
 	The purpose of this request is to allow clients to render content
-	according to the output transform, thus permiting the compositor to
+	according to the output transform, thus permitting the compositor to
 	use certain optimizations even if the display is rotated. Using
 	hardware overlays and scanning out a client buffer for fullscreen
 	surfaces are examples of such optimizations. Those optimizations are
@@ -1212,8 +1742,13 @@
 	Note that if the transform value includes 90 or 270 degree rotation,
 	the width of the buffer will become the surface height and the height
 	of the buffer will become the surface width.
+
+	If transform is not one of the values from the
+	wl_output.transform enum the invalid_transform protocol error
+	is raised.
       </description>
-      <arg name="transform" type="int"/>
+      <arg name="transform" type="int" enum="wl_output.transform"
+	   summary="transform for interpreting buffer contents"/>
     </request>
 
     <!-- Version 3 additions -->
@@ -1227,21 +1762,131 @@
 
 	A newly created surface has its buffer scale set to 1.
 
+	wl_surface.set_buffer_scale changes the pending buffer scale.
+	wl_surface.commit copies the pending buffer scale to the current one.
+	Otherwise, the pending and current values are never changed.
+
 	The purpose of this request is to allow clients to supply higher
-	resolution buffer data for use on high resolution outputs. Its
-	intended that you pick the same	buffer scale as the scale of the
-	output that the surface is displayed on.This means the compositor
+	resolution buffer data for use on high resolution outputs. It is
+	intended that you pick the same buffer scale as the scale of the
+	output that the surface is displayed on. This means the compositor
 	can avoid scaling when rendering the surface on that output.
 
 	Note that if the scale is larger than 1, then you have to attach
 	a buffer that is larger (by a factor of scale in each dimension)
 	than the desired surface size.
+
+	If scale is not greater than 0 the invalid_scale protocol error is
+	raised.
       </description>
-      <arg name="scale" type="int"/>
+      <arg name="scale" type="int"
+	   summary="scale for interpreting buffer contents"/>
     </request>
+
+    <!-- Version 4 additions -->
+    <request name="damage_buffer" since="4">
+      <description summary="mark part of the surface damaged using buffer coordinates">
+	This request is used to describe the regions where the pending
+	buffer is different from the current surface contents, and where
+	the surface therefore needs to be repainted. The compositor
+	ignores the parts of the damage that fall outside of the surface.
+
+	Damage is double-buffered state, see wl_surface.commit.
+
+	The damage rectangle is specified in buffer coordinates,
+	where x and y specify the upper left corner of the damage rectangle.
+
+	The initial value for pending damage is empty: no damage.
+	wl_surface.damage_buffer adds pending damage: the new pending
+	damage is the union of old pending damage and the given rectangle.
+
+	wl_surface.commit assigns pending damage as the current damage,
+	and clears pending damage. The server will clear the current
+	damage as it repaints the surface.
+
+	This request differs from wl_surface.damage in only one way - it
+	takes damage in buffer coordinates instead of surface-local
+	coordinates. While this generally is more intuitive than surface
+	coordinates, it is especially desirable when using wp_viewport
+	or when a drawing library (like EGL) is unaware of buffer scale
+	and buffer transform.
+
+	Note: Because buffer transformation changes and damage requests may
+	be interleaved in the protocol stream, it is impossible to determine
+	the actual mapping between surface and buffer damage until
+	wl_surface.commit time. Therefore, compositors wishing to take both
+	kinds of damage into account will have to accumulate damage from the
+	two requests separately and only transform from one to the other
+	after receiving the wl_surface.commit.
+      </description>
+      <arg name="x" type="int" summary="buffer-local x coordinate"/>
+      <arg name="y" type="int" summary="buffer-local y coordinate"/>
+      <arg name="width" type="int" summary="width of damage rectangle"/>
+      <arg name="height" type="int" summary="height of damage rectangle"/>
+    </request>
+
+    <!-- Version 5 additions -->
+
+    <request name="offset" since="5">
+      <description summary="set the surface contents offset">
+	The x and y arguments specify the location of the new pending
+	buffer's upper left corner, relative to the current buffer's upper
+	left corner, in surface-local coordinates. In other words, the
+	x and y, combined with the new surface size define in which
+	directions the surface's size changes.
+
+	The exact semantics of wl_surface.offset are role-specific. Refer to
+	the documentation of specific roles for more information.
+
+	Surface location offset is double-buffered state, see
+	wl_surface.commit.
+
+	This request is semantically equivalent to and the replaces the x and y
+	arguments in the wl_surface.attach request in wl_surface versions prior
+	to 5. See wl_surface.attach for details.
+      </description>
+      <arg name="x" type="int" summary="surface-local x coordinate"/>
+      <arg name="y" type="int" summary="surface-local y coordinate"/>
+    </request>
+
+    <!-- Version 6 additions -->
+
+    <event name="preferred_buffer_scale" since="6">
+      <description summary="preferred buffer scale for the surface">
+	This event indicates the preferred buffer scale for this surface. It is
+	sent whenever the compositor's preference changes.
+
+	Before receiving this event the preferred buffer scale for this surface
+	is 1.
+
+	It is intended that scaling aware clients use this event to scale their
+	content and use wl_surface.set_buffer_scale to indicate the scale they
+	have rendered with. This allows clients to supply a higher detail
+	buffer.
+
+	The compositor shall emit a scale value greater than 0.
+      </description>
+      <arg name="factor" type="int" summary="preferred scaling factor"/>
+    </event>
+
+    <event name="preferred_buffer_transform" since="6">
+      <description summary="preferred buffer transform for the surface">
+	This event indicates the preferred buffer transform for this surface.
+	It is sent whenever the compositor's preference changes.
+
+	Before receiving this event the preferred buffer transform for this
+	surface is normal.
+
+	Applying this transformation to the surface buffer contents and using
+	wl_surface.set_buffer_transform might allow the compositor to use the
+	surface buffer more efficiently.
+      </description>
+      <arg name="transform" type="uint" enum="wl_output.transform"
+	   summary="preferred transform"/>
+    </event>
    </interface>
 
-  <interface name="wl_seat" version="3">
+  <interface name="wl_seat" version="10">
     <description summary="group of input devices">
       A seat is a group of keyboards, pointer and touch devices. This
       object is published as a global during start up, or when such a
@@ -1249,72 +1894,133 @@
       maintains a keyboard focus and a pointer focus.
     </description>
 
-    <enum name="capability">
+    <enum name="capability" bitfield="true">
       <description summary="seat capability bitmask">
-        This is a bitmask of capabilities this seat has; if a member is
-        set, then it is present on the seat.
+	This is a bitmask of capabilities this seat has; if a member is
+	set, then it is present on the seat.
       </description>
-      <entry name="pointer" value="1" summary="The seat has pointer devices"/>
-      <entry name="keyboard" value="2" summary="The seat has one or more keyboards"/>
-      <entry name="touch" value="4" summary="The seat has touch devices"/>
+      <entry name="pointer" value="1" summary="the seat has pointer devices"/>
+      <entry name="keyboard" value="2" summary="the seat has one or more keyboards"/>
+      <entry name="touch" value="4" summary="the seat has touch devices"/>
+    </enum>
+
+    <enum name="error">
+      <description summary="wl_seat error values">
+	These errors can be emitted in response to wl_seat requests.
+      </description>
+      <entry name="missing_capability" value="0"
+	     summary="get_pointer, get_keyboard or get_touch called on seat without the matching capability"/>
     </enum>
 
     <event name="capabilities">
       <description summary="seat capabilities changed">
-        This is emitted whenever a seat gains or loses the pointer,
-	keyboard or touch capabilities.  The argument is a capability
-	enum containing the complete set of capabilities this seat has.
+	This is sent on binding to the seat global or whenever a seat gains
+	or loses the pointer, keyboard or touch capabilities.
+	The argument is a capability enum containing the complete set of
+	capabilities this seat has.
+
+	When the pointer capability is added, a client may create a
+	wl_pointer object using the wl_seat.get_pointer request. This object
+	will receive pointer events until the capability is removed in the
+	future.
+
+	When the pointer capability is removed, a client should destroy the
+	wl_pointer objects associated with the seat where the capability was
+	removed, using the wl_pointer.release request. No further pointer
+	events will be received on these objects.
+
+	In some compositors, if a seat regains the pointer capability and a
+	client has a previously obtained wl_pointer object of version 4 or
+	less, that object may start sending pointer events again. This
+	behavior is considered a misinterpretation of the intended behavior
+	and must not be relied upon by the client. wl_pointer objects of
+	version 5 or later must not send events if created before the most
+	recent event notifying the client of an added pointer capability.
+
+	The above behavior also applies to wl_keyboard and wl_touch with the
+	keyboard and touch capabilities, respectively.
       </description>
-      <arg name="capabilities" type="uint"/>
+      <arg name="capabilities" type="uint" enum="capability" summary="capabilities of the seat"/>
     </event>
 
     <request name="get_pointer">
       <description summary="return pointer object">
-        The ID provided will be initialized to the wl_pointer interface
+	The ID provided will be initialized to the wl_pointer interface
 	for this seat.
 
-        This request only takes effect if the seat has the pointer
-        capability.
+	This request only takes effect if the seat has the pointer
+	capability, or has had the pointer capability in the past.
+	It is a protocol violation to issue this request on a seat that has
+	never had the pointer capability. The missing_capability error will
+	be sent in this case.
       </description>
-      <arg name="id" type="new_id" interface="wl_pointer"/>
+      <arg name="id" type="new_id" interface="wl_pointer" summary="seat pointer"/>
     </request>
 
     <request name="get_keyboard">
       <description summary="return keyboard object">
-        The ID provided will be initialized to the wl_keyboard interface
+	The ID provided will be initialized to the wl_keyboard interface
 	for this seat.
 
-        This request only takes effect if the seat has the keyboard
-        capability.
+	This request only takes effect if the seat has the keyboard
+	capability, or has had the keyboard capability in the past.
+	It is a protocol violation to issue this request on a seat that has
+	never had the keyboard capability. The missing_capability error will
+	be sent in this case.
       </description>
-      <arg name="id" type="new_id" interface="wl_keyboard"/>
+      <arg name="id" type="new_id" interface="wl_keyboard" summary="seat keyboard"/>
     </request>
 
     <request name="get_touch">
       <description summary="return touch object">
-        The ID provided will be initialized to the wl_touch interface
+	The ID provided will be initialized to the wl_touch interface
 	for this seat.
 
-        This request only takes effect if the seat has the touch
-        capability.
+	This request only takes effect if the seat has the touch
+	capability, or has had the touch capability in the past.
+	It is a protocol violation to issue this request on a seat that has
+	never had the touch capability. The missing_capability error will
+	be sent in this case.
       </description>
-      <arg name="id" type="new_id" interface="wl_touch"/>
+      <arg name="id" type="new_id" interface="wl_touch" summary="seat touch interface"/>
     </request>
 
-    <!-- Version 2 of additions -->
+    <!-- Version 2 additions -->
 
     <event name="name" since="2">
       <description summary="unique identifier for this seat">
-	In a multiseat configuration this can be used by the client to help
-	identify which physical devices the seat represents. Based on
-	the seat configuration used by the compositor.
+	In a multi-seat configuration the seat name can be used by clients to
+	help identify which physical devices the seat represents.
+
+	The seat name is a UTF-8 string with no convention defined for its
+	contents. Each name is unique among all wl_seat globals. The name is
+	only guaranteed to be unique for the current compositor instance.
+
+	The same seat names are used for all clients. Thus, the name can be
+	shared across processes to refer to a specific wl_seat global.
+
+	The name event is sent after binding to the seat global, and should be sent
+	before announcing capabilities. This event only sent once per seat object,
+	and the name does not change over the lifetime of the wl_seat global.
+
+	Compositors may re-use the same seat name if the wl_seat global is
+	destroyed and re-created later.
       </description>
-      <arg name="name" type="string"/>
+      <arg name="name" type="string" summary="seat identifier"/>
     </event>
+
+    <!-- Version 5 additions -->
+
+    <request name="release" type="destructor" since="5">
+      <description summary="release the seat object">
+	Using this request a client can tell the server that it is not going to
+	use the seat object anymore.
+      </description>
+    </request>
 
   </interface>
 
-  <interface name="wl_pointer" version="3">
+  <interface name="wl_pointer" version="10">
     <description summary="pointer input device">
       The wl_pointer interface represents one or more input devices,
       such as mice, which control the pointer location and pointer_focus
@@ -1326,10 +2032,18 @@
       and scrolling.
     </description>
 
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+    </enum>
+
     <request name="set_cursor">
       <description summary="set the pointer surface">
 	Set the pointer surface, i.e., the surface that contains the
-	pointer image (cursor). This request only takes effect if the pointer
+	pointer image (cursor). This request gives the surface the role
+	of a cursor. If the surface already has another role, it raises
+	a protocol error.
+
+	The cursor actually changes only if the pointer
 	focus for this device is one of the requesting client's surfaces
 	or the surface parameter is the current pointer surface. If
 	there was a previous surface set with this request it is
@@ -1338,33 +2052,31 @@
 	The parameters hotspot_x and hotspot_y define the position of
 	the pointer surface relative to the pointer location. Its
 	top-left corner is always at (x, y) - (hotspot_x, hotspot_y),
-	where (x, y) are the coordinates of the pointer location, in surface
-	local coordinates.
+	where (x, y) are the coordinates of the pointer location, in
+	surface-local coordinates.
 
-	On surface.attach requests to the pointer surface, hotspot_x
+	On wl_surface.offset requests to the pointer surface, hotspot_x
 	and hotspot_y are decremented by the x and y parameters
-	passed to the request. Attach must be confirmed by
+	passed to the request. The offset must be applied by
 	wl_surface.commit as usual.
 
 	The hotspot can also be updated by passing the currently set
 	pointer surface to this request with new values for hotspot_x
 	and hotspot_y.
 
-	The current and pending input regions of the wl_surface are
-	cleared, and wl_surface.set_input_region is ignored until the
-	wl_surface is no longer used as the cursor. When the use as a
-	cursor ends, the current and pending input regions become
-	undefined, and the wl_surface is unmapped.
+	The input region is ignored for wl_surfaces with the role of
+	a cursor. When the use as a cursor ends, the wl_surface is
+	unmapped.
+
+	The serial parameter must match the latest wl_pointer.enter
+	serial number sent to the client. Otherwise the request will be
+	ignored.
       </description>
-
-      <arg name="serial" type="uint" summary="serial of the enter event"/>
-      <arg name="surface" type="object" interface="wl_surface" allow-null="true"/>
-      <arg name="hotspot_x" type="int" summary="x coordinate in surface-relative coordinates"/>
-      <arg name="hotspot_y" type="int" summary="y coordinate in surface-relative coordinates"/>
-    </request>
-
-    <request name="release" type="destructor" since="3">
-      <description summary="release the pointer object"/>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="surface" type="object" interface="wl_surface" allow-null="true"
+	   summary="pointer surface"/>
+      <arg name="hotspot_x" type="int" summary="surface-local x coordinate"/>
+      <arg name="hotspot_y" type="int" summary="surface-local y coordinate"/>
     </request>
 
     <event name="enter">
@@ -1372,15 +2084,14 @@
 	Notification that this seat's pointer is focused on a certain
 	surface.
 
-	When an seat's focus enters a surface, the pointer image
+	When a seat's focus enters a surface, the pointer image
 	is undefined and a client should respond to this event by setting
 	an appropriate pointer image with the set_cursor request.
       </description>
-
-      <arg name="serial" type="uint"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
-      <arg name="surface_x" type="fixed" summary="x coordinate in surface-relative coordinates"/>
-      <arg name="surface_y" type="fixed" summary="y coordinate in surface-relative coordinates"/>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface entered by the pointer"/>
+      <arg name="surface_x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="surface_y" type="fixed" summary="surface-local y coordinate"/>
     </event>
 
     <event name="leave">
@@ -1391,8 +2102,8 @@
 	The leave notification is sent before the enter notification
 	for the new focus.
       </description>
-      <arg name="serial" type="uint"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="serial" type="uint" summary="serial number of the leave event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface left by the pointer"/>
     </event>
 
     <event name="motion">
@@ -1401,19 +2112,18 @@
 	surface_x and surface_y are the location relative to the
 	focused surface.
       </description>
-
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
-      <arg name="surface_x" type="fixed" summary="x coordinate in surface-relative coordinates"/>
-      <arg name="surface_y" type="fixed" summary="y coordinate in surface-relative coordinates"/>
+      <arg name="surface_x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="surface_y" type="fixed" summary="surface-local y coordinate"/>
     </event>
 
     <enum name="button_state">
       <description summary="physical button state">
-        Describes the physical state of a button which provoked the button
+	Describes the physical state of a button that produced the button
 	event.
       </description>
-      <entry name="released" value="0" summary="The button is not pressed"/>
-      <entry name="pressed" value="1" summary="The button is pressed"/>
+      <entry name="released" value="0" summary="the button is not pressed"/>
+      <entry name="pressed" value="1" summary="the button is pressed"/>
     </enum>
 
     <event name="button">
@@ -1422,22 +2132,29 @@
 
 	The location of the click is given by the last motion or
 	enter event.
-        The time argument is a timestamp with millisecond
-        granularity, with an undefined base.
-      </description>
+	The time argument is a timestamp with millisecond
+	granularity, with an undefined base.
 
-      <arg name="serial" type="uint"/>
+	The button is a button code as defined in the Linux kernel's
+	linux/input-event-codes.h header file, e.g. BTN_LEFT.
+
+	Any 16-bit button code value is reserved for future additions to the
+	kernel's event code list. All other button codes above 0xFFFF are
+	currently undefined but may be used in future versions of this
+	protocol.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the button event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
-      <arg name="button" type="uint"/>
-      <arg name="state" type="uint"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="button_state" summary="physical state of the button"/>
     </event>
 
     <enum name="axis">
       <description summary="axis types">
 	Describes the axis types of scroll events.
       </description>
-      <entry name="vertical_scroll" value="0"/>
-      <entry name="horizontal_scroll" value="1"/>
+      <entry name="vertical_scroll" value="0" summary="vertical axis"/>
+      <entry name="horizontal_scroll" value="1" summary="horizontal axis"/>
     </enum>
 
     <event name="axis">
@@ -1456,25 +2173,281 @@
 	choose to emit scroll events where the motion vector is
 	equivalent to a motion event vector.
 
-	When applicable, clients can transform its view relative to the
+	When applicable, a client can transform its content relative to the
 	scroll distance.
       </description>
-
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
-      <arg name="axis" type="uint"/>
-      <arg name="value" type="fixed"/>
+      <arg name="axis" type="uint" enum="axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in surface-local coordinate space"/>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="release the pointer object">
+	Using this request a client can tell the server that it is not going to
+	use the pointer object anymore.
+
+	This request destroys the pointer proxy object, so clients must not call
+	wl_pointer_destroy() after using this request.
+      </description>
+    </request>
+
+    <!-- Version 5 additions -->
+
+    <event name="frame" since="5">
+      <description summary="end of a pointer event sequence">
+	Indicates the end of a set of events that logically belong together.
+	A client is expected to accumulate the data in all events within the
+	frame before proceeding.
+
+	All wl_pointer events before a wl_pointer.frame event belong
+	logically together. For example, in a diagonal scroll motion the
+	compositor will send an optional wl_pointer.axis_source event, two
+	wl_pointer.axis events (horizontal and vertical) and finally a
+	wl_pointer.frame event. The client may use this information to
+	calculate a diagonal vector for scrolling.
+
+	When multiple wl_pointer.axis events occur within the same frame,
+	the motion vector is the combined motion of all events.
+	When a wl_pointer.axis and a wl_pointer.axis_stop event occur within
+	the same frame, this indicates that axis movement in one axis has
+	stopped but continues in the other axis.
+	When multiple wl_pointer.axis_stop events occur within the same
+	frame, this indicates that these axes stopped in the same instance.
+
+	A wl_pointer.frame event is sent for every logical event group,
+	even if the group only contains a single wl_pointer event.
+	Specifically, a client may get a sequence: motion, frame, button,
+	frame, axis, frame, axis_stop, frame.
+
+	The wl_pointer.enter and wl_pointer.leave events are logical events
+	generated by the compositor and not the hardware. These events are
+	also grouped by a wl_pointer.frame. When a pointer moves from one
+	surface to another, a compositor should group the
+	wl_pointer.leave event within the same wl_pointer.frame.
+	However, a client must not rely on wl_pointer.leave and
+	wl_pointer.enter being in the same wl_pointer.frame.
+	Compositor-specific policies may require the wl_pointer.leave and
+	wl_pointer.enter event being split across multiple wl_pointer.frame
+	groups.
+      </description>
+    </event>
+
+    <enum name="axis_source">
+      <description summary="axis source types">
+	Describes the source types for axis events. This indicates to the
+	client how an axis event was physically generated; a client may
+	adjust the user interface accordingly. For example, scroll events
+	from a "finger" source may be in a smooth coordinate space with
+	kinetic scrolling whereas a "wheel" source may be in discrete steps
+	of a number of lines.
+
+	The "continuous" axis source is a device generating events in a
+	continuous coordinate space, but using something other than a
+	finger. One example for this source is button-based scrolling where
+	the vertical motion of a device is converted to scroll events while
+	a button is held down.
+
+	The "wheel tilt" axis source indicates that the actual device is a
+	wheel but the scroll event is not caused by a rotation but a
+	(usually sideways) tilt of the wheel.
+      </description>
+      <entry name="wheel" value="0" summary="a physical wheel rotation" />
+      <entry name="finger" value="1" summary="finger on a touch surface" />
+      <entry name="continuous" value="2" summary="continuous coordinate space"/>
+      <entry name="wheel_tilt" value="3" summary="a physical wheel tilt" since="6"/>
+    </enum>
+
+    <event name="axis_source" since="5">
+      <description summary="axis source event">
+	Source information for scroll and other axes.
+
+	This event does not occur on its own. It is sent before a
+	wl_pointer.frame event and carries the source information for
+	all events within that frame.
+
+	The source specifies how this event was generated. If the source is
+	wl_pointer.axis_source.finger, a wl_pointer.axis_stop event will be
+	sent when the user lifts the finger off the device.
+
+	If the source is wl_pointer.axis_source.wheel,
+	wl_pointer.axis_source.wheel_tilt or
+	wl_pointer.axis_source.continuous, a wl_pointer.axis_stop event may
+	or may not be sent. Whether a compositor sends an axis_stop event
+	for these sources is hardware-specific and implementation-dependent;
+	clients must not rely on receiving an axis_stop event for these
+	scroll sources and should treat scroll sequences from these scroll
+	sources as unterminated by default.
+
+	This event is optional. If the source is unknown for a particular
+	axis event sequence, no event is sent.
+	Only one wl_pointer.axis_source event is permitted per frame.
+
+	The order of wl_pointer.axis_discrete and wl_pointer.axis_source is
+	not guaranteed.
+      </description>
+      <arg name="axis_source" type="uint" enum="axis_source" summary="source of the axis event"/>
+    </event>
+
+    <event name="axis_stop" since="5">
+      <description summary="axis stop event">
+	Stop notification for scroll and other axes.
+
+	For some wl_pointer.axis_source types, a wl_pointer.axis_stop event
+	is sent to notify a client that the axis sequence has terminated.
+	This enables the client to implement kinetic scrolling.
+	See the wl_pointer.axis_source documentation for information on when
+	this event may be generated.
+
+	Any wl_pointer.axis events with the same axis_source after this
+	event should be considered as the start of a new axis motion.
+
+	The timestamp is to be interpreted identical to the timestamp in the
+	wl_pointer.axis event. The timestamp value may be the same as a
+	preceding wl_pointer.axis event.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="axis" summary="the axis stopped with this event"/>
+    </event>
+
+    <event name="axis_discrete" since="5" deprecated-since="8">
+      <description summary="axis click event">
+	Discrete step information for scroll and other axes.
+
+	This event carries the axis value of the wl_pointer.axis event in
+	discrete steps (e.g. mouse wheel clicks).
+
+	This event is deprecated with wl_pointer version 8 - this event is not
+	sent to clients supporting version 8 or later.
+
+	This event does not occur on its own, it is coupled with a
+	wl_pointer.axis event that represents this axis value on a
+	continuous scale. The protocol guarantees that each axis_discrete
+	event is always followed by exactly one axis event with the same
+	axis number within the same wl_pointer.frame. Note that the protocol
+	allows for other events to occur between the axis_discrete and
+	its coupled axis event, including other axis_discrete or axis
+	events. A wl_pointer.frame must not contain more than one axis_discrete
+	event per axis type.
+
+	This event is optional; continuous scrolling devices
+	like two-finger scrolling on touchpads do not have discrete
+	steps and do not generate this event.
+
+	The discrete value carries the directional information. e.g. a value
+	of -2 is two steps towards the negative direction of this axis.
+
+	The axis number is identical to the axis number in the associated
+	axis event.
+
+	The order of wl_pointer.axis_discrete and wl_pointer.axis_source is
+	not guaranteed.
+      </description>
+      <arg name="axis" type="uint" enum="axis" summary="axis type"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </event>
+
+    <event name="axis_value120" since="8">
+      <description summary="axis high-resolution scroll event">
+	Discrete high-resolution scroll information.
+
+	This event carries high-resolution wheel scroll information,
+	with each multiple of 120 representing one logical scroll step
+	(a wheel detent). For example, an axis_value120 of 30 is one quarter of
+	a logical scroll step in the positive direction, a value120 of
+	-240 are two logical scroll steps in the negative direction within the
+	same hardware event.
+	Clients that rely on discrete scrolling should accumulate the
+	value120 to multiples of 120 before processing the event.
+
+	The value120 must not be zero.
+
+	This event replaces the wl_pointer.axis_discrete event in clients
+	supporting wl_pointer version 8 or later.
+
+	Where a wl_pointer.axis_source event occurs in the same
+	wl_pointer.frame, the axis source applies to this event.
+
+	The order of wl_pointer.axis_value120 and wl_pointer.axis_source is
+	not guaranteed.
+      </description>
+      <arg name="axis" type="uint" enum="axis" summary="axis type"/>
+      <arg name="value120" type="int" summary="scroll distance as fraction of 120"/>
+    </event>
+
+    <!-- Version 9 additions -->
+
+    <enum name="axis_relative_direction">
+      <description summary="axis relative direction">
+	This specifies the direction of the physical motion that caused a
+	wl_pointer.axis event, relative to the wl_pointer.axis direction.
+      </description>
+      <entry name="identical" value="0"
+	  summary="physical motion matches axis direction"/>
+      <entry name="inverted" value="1"
+	  summary="physical motion is the inverse of the axis direction"/>
+    </enum>
+
+    <event name="axis_relative_direction" since="9">
+      <description summary="axis relative physical direction event">
+	Relative directional information of the entity causing the axis
+	motion.
+
+	For a wl_pointer.axis event, the wl_pointer.axis_relative_direction
+	event specifies the movement direction of the entity causing the
+	wl_pointer.axis event. For example:
+	- if a user's fingers on a touchpad move down and this
+	  causes a wl_pointer.axis vertical_scroll down event, the physical
+	  direction is 'identical'
+	- if a user's fingers on a touchpad move down and this causes a
+	  wl_pointer.axis vertical_scroll up scroll up event ('natural
+	  scrolling'), the physical direction is 'inverted'.
+
+	A client may use this information to adjust scroll motion of
+	components. Specifically, enabling natural scrolling causes the
+	content to change direction compared to traditional scrolling.
+	Some widgets like volume control sliders should usually match the
+	physical direction regardless of whether natural scrolling is
+	active. This event enables clients to match the scroll direction of
+	a widget to the physical direction.
+
+	This event does not occur on its own, it is coupled with a
+	wl_pointer.axis event that represents this axis value.
+	The protocol guarantees that each axis_relative_direction event is
+	always followed by exactly one axis event with the same
+	axis number within the same wl_pointer.frame. Note that the protocol
+	allows for other events to occur between the axis_relative_direction
+	and its coupled axis event.
+
+	The axis number is identical to the axis number in the associated
+	axis event.
+
+	The order of wl_pointer.axis_relative_direction,
+	wl_pointer.axis_discrete and wl_pointer.axis_source is not
+	guaranteed.
+      </description>
+      <arg name="axis" type="uint" enum="axis" summary="axis type"/>
+      <arg name="direction" type="uint" enum="axis_relative_direction"
+	  summary="physical direction relative to axis motion"/>
     </event>
   </interface>
 
-  <interface name="wl_keyboard" version="3">
+  <interface name="wl_keyboard" version="10">
     <description summary="keyboard input device">
       The wl_keyboard interface represents one or more keyboards
       associated with a seat.
-    </description>
 
-    <request name="release" type="destructor" since="3">
-      <description summary="release the keyboard object"/>
-    </request>
+      Each wl_keyboard has the following logical state:
+
+      - an active surface (possibly null),
+      - the keys currently logically down,
+      - the active modifiers,
+      - the active group.
+
+      By default, the active surface is null, the keys currently logically down
+      are empty, the active modifiers and the active group are 0.
+    </description>
 
     <enum name="keymap_format">
       <description summary="keyboard mapping format">
@@ -1483,27 +2456,43 @@
       </description>
       <entry name="no_keymap" value="0"
 	     summary="no keymap; client must understand how to interpret the raw keycode"/>
-      <entry name="xkb_v1" value="1" summary="libxkbcommon compatible"/>
+      <entry name="xkb_v1" value="1"
+	     summary="libxkbcommon compatible, null-terminated string; to determine the xkb keycode, clients must add 8 to the key event keycode"/>
     </enum>
 
     <event name="keymap">
       <description summary="keyboard mapping">
 	This event provides a file descriptor to the client which can be
-	memory-mapped to provide a keyboard mapping description.
+	memory-mapped in read-only mode to provide a keyboard mapping
+	description.
+
+	From version 7 onwards, the fd must be mapped with MAP_PRIVATE by
+	the recipient, as MAP_SHARED may fail.
       </description>
-      <arg name="format" type="uint"/>
-      <arg name="fd" type="fd"/>
-      <arg name="size" type="uint"/>
+      <arg name="format" type="uint" enum="keymap_format" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
     </event>
 
     <event name="enter">
       <description summary="enter event">
 	Notification that this seat's keyboard focus is on a certain
 	surface.
+
+	The compositor must send the wl_keyboard.modifiers event after this
+	event.
+
+	In the wl_keyboard logical state, this event sets the active surface to
+	the surface argument and the keys currently logically down to the keys
+	in the keys argument. The compositor must not send this event if the
+	wl_keyboard already had an active surface immediately before this event.
+
+	Clients should not use the list of pressed keys to emulate key-press
+	events. The order of keys in the list is unspecified.
       </description>
-      <arg name="serial" type="uint"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
-      <arg name="keys" type="array" summary="the currently pressed keys"/>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface gaining keyboard focus"/>
+      <arg name="keys" type="array" summary="the keys currently logically down"/>
     </event>
 
     <event name="leave">
@@ -1513,47 +2502,119 @@
 
 	The leave notification is sent before the enter notification
 	for the new focus.
+
+	In the wl_keyboard logical state, this event resets all values to their
+	defaults. The compositor must not send this event if the active surface
+	of the wl_keyboard was not equal to the surface argument immediately
+	before this event.
       </description>
-      <arg name="serial" type="uint"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="serial" type="uint" summary="serial number of the leave event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface that lost keyboard focus"/>
     </event>
 
     <enum name="key_state">
       <description summary="physical key state">
-	Describes the physical state of a key which provoked the key event.
+	Describes the physical state of a key that produced the key event.
+
+	Since version 10, the key can be in a "repeated" pseudo-state which
+	means the same as "pressed", but is used to signal repetition in the
+	key event.
+
+	The key may only enter the repeated state after entering the pressed
+	state and before entering the released state. This event may be
+	generated multiple times while the key is down.
       </description>
       <entry name="released" value="0" summary="key is not pressed"/>
       <entry name="pressed" value="1" summary="key is pressed"/>
+      <entry name="repeated" value="2" summary="key was repeated" since="10"/>
     </enum>
 
     <event name="key">
       <description summary="key event">
 	A key was pressed or released.
-        The time argument is a timestamp with millisecond
-        granularity, with an undefined base.
-      </description>
+	The time argument is a timestamp with millisecond
+	granularity, with an undefined base.
 
-      <arg name="serial" type="uint"/>
+	The key is a platform-specific key code that can be interpreted
+	by feeding it to the keyboard mapping (see the keymap event).
+
+	If this event produces a change in modifiers, then the resulting
+	wl_keyboard.modifiers event must be sent after this event.
+
+	In the wl_keyboard logical state, this event adds the key to the keys
+	currently logically down (if the state argument is pressed) or removes
+	the key from the keys currently logically down (if the state argument is
+	released). The compositor must not send this event if the wl_keyboard
+	did not have an active surface immediately before this event. The
+	compositor must not send this event if state is pressed (resp. released)
+	and the key was already logically down (resp. was not logically down)
+	immediately before this event.
+
+	Since version 10, compositors may send key events with the "repeated"
+	key state when a wl_keyboard.repeat_info event with a rate argument of
+	0 has been received. This allows the compositor to take over the
+	responsibility of key repetition.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the key event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
-      <arg name="key" type="uint"/>
-      <arg name="state" type="uint"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" enum="key_state" summary="physical state of the key"/>
     </event>
 
     <event name="modifiers">
       <description summary="modifier and group state">
 	Notifies clients that the modifier and/or group state has
 	changed, and it should update its local state.
-      </description>
 
-      <arg name="serial" type="uint"/>
-      <arg name="mods_depressed" type="uint"/>
-      <arg name="mods_latched" type="uint"/>
-      <arg name="mods_locked" type="uint"/>
-      <arg name="group" type="uint"/>
+	The compositor may send this event without a surface of the client
+	having keyboard focus, for example to tie modifier information to
+	pointer focus instead. If a modifier event with pressed modifiers is sent
+	without a prior enter event, the client can assume the modifier state is
+	valid until it receives the next wl_keyboard.modifiers event. In order to
+	reset the modifier state again, the compositor can send a
+	wl_keyboard.modifiers event with no pressed modifiers.
+
+	In the wl_keyboard logical state, this event updates the modifiers and
+	group.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the modifiers event"/>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="release the keyboard object"/>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <event name="repeat_info" since="4">
+      <description summary="repeat rate and delay">
+	Informs the client about the keyboard's repeat rate and delay.
+
+	This event is sent as soon as the wl_keyboard object has been created,
+	and is guaranteed to be received by the client before any key press
+	event.
+
+	Negative values for either rate or delay are illegal. A rate of zero
+	will disable any repeating (regardless of the value of delay).
+
+	This event can be sent later on as well with a new value if necessary,
+	so clients should continue listening for the event past the creation
+	of wl_keyboard.
+      </description>
+      <arg name="rate" type="int"
+	   summary="the rate of repeating keys in characters per second"/>
+      <arg name="delay" type="int"
+	   summary="delay in milliseconds since key down until repeating starts"/>
     </event>
   </interface>
 
-  <interface name="wl_touch" version="3">
+  <interface name="wl_touch" version="10">
     <description summary="touchscreen input device">
       The wl_touch interface represents a touchscreen
       associated with a seat.
@@ -1565,49 +2626,52 @@
       contact point can be identified by the ID of the sequence.
     </description>
 
-    <request name="release" type="destructor" since="3">
-      <description summary="release the touch object"/>
-    </request>
-
     <event name="down">
       <description summary="touch down event and beginning of a touch sequence">
 	A new touch point has appeared on the surface. This touch point is
-	assigned a unique @id. Future events from this touchpoint reference
+	assigned a unique ID. Future events from this touch point reference
 	this ID. The ID ceases to be valid after a touch up event and may be
-	re-used in the future.
+	reused in the future.
       </description>
-      <arg name="serial" type="uint"/>
+      <arg name="serial" type="uint" summary="serial number of the touch down event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
-      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface touched"/>
       <arg name="id" type="int" summary="the unique ID of this touch point"/>
-      <arg name="x" type="fixed" summary="x coordinate in surface-relative coordinates"/>
-      <arg name="y" type="fixed" summary="y coordinate in surface-relative coordinates"/>
+      <arg name="x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="y" type="fixed" summary="surface-local y coordinate"/>
     </event>
 
     <event name="up">
       <description summary="end of a touch event sequence">
 	The touch point has disappeared. No further events will be sent for
-	this touchpoint and the touch point's ID is released and may be
-	re-used in a future touch down event.
+	this touch point and the touch point's ID is released and may be
+	reused in a future touch down event.
       </description>
-      <arg name="serial" type="uint"/>
+      <arg name="serial" type="uint" summary="serial number of the touch up event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="id" type="int" summary="the unique ID of this touch point"/>
     </event>
 
     <event name="motion">
       <description summary="update of touch point coordinates">
-	A touchpoint has changed coordinates.
+	A touch point has changed coordinates.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="id" type="int" summary="the unique ID of this touch point"/>
-      <arg name="x" type="fixed" summary="x coordinate in surface-relative coordinates"/>
-      <arg name="y" type="fixed" summary="y coordinate in surface-relative coordinates"/>
+      <arg name="x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="y" type="fixed" summary="surface-local y coordinate"/>
     </event>
 
     <event name="frame">
       <description summary="end of touch frame event">
-	Indicates the end of a contact point list.
+	Indicates the end of a set of events that logically belong together.
+	A client is expected to accumulate the data in all events within the
+	frame before proceeding.
+
+	A wl_touch.frame terminates at least one event but otherwise no
+	guarantee is provided about the set of events within a frame. A client
+	must assume that any state not updated in a frame is unchanged from the
+	previously known state.
       </description>
     </event>
 
@@ -1618,16 +2682,89 @@
 	particular gesture. Touch cancellation applies to all touch points
 	currently active on this client's surface. The client is
 	responsible for finalizing the touch points, future touch points on
-	this surface may re-use the touch point ID.
+	this surface may reuse the touch point ID.
+
+	No frame event is required after the cancel event.
       </description>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="release the touch object"/>
+    </request>
+
+    <!-- Version 6 additions -->
+
+    <event name="shape" since="6">
+      <description summary="update shape of touch point">
+	Sent when a touchpoint has changed its shape.
+
+	This event does not occur on its own. It is sent before a
+	wl_touch.frame event and carries the new shape information for
+	any previously reported, or new touch points of that frame.
+
+	Other events describing the touch point such as wl_touch.down,
+	wl_touch.motion or wl_touch.orientation may be sent within the
+	same wl_touch.frame. A client should treat these events as a single
+	logical touch point update. The order of wl_touch.shape,
+	wl_touch.orientation and wl_touch.motion is not guaranteed.
+	A wl_touch.down event is guaranteed to occur before the first
+	wl_touch.shape event for this touch ID but both events may occur within
+	the same wl_touch.frame.
+
+	A touchpoint shape is approximated by an ellipse through the major and
+	minor axis length. The major axis length describes the longer diameter
+	of the ellipse, while the minor axis length describes the shorter
+	diameter. Major and minor are orthogonal and both are specified in
+	surface-local coordinates. The center of the ellipse is always at the
+	touchpoint location as reported by wl_touch.down or wl_touch.move.
+
+	This event is only sent by the compositor if the touch device supports
+	shape reports. The client has to make reasonable assumptions about the
+	shape if it did not receive this event.
+      </description>
+      <arg name="id" type="int" summary="the unique ID of this touch point"/>
+      <arg name="major" type="fixed" summary="length of the major axis in surface-local coordinates"/>
+      <arg name="minor" type="fixed" summary="length of the minor axis in surface-local coordinates"/>
+    </event>
+
+    <event name="orientation" since="6">
+      <description summary="update orientation of touch point">
+	Sent when a touchpoint has changed its orientation.
+
+	This event does not occur on its own. It is sent before a
+	wl_touch.frame event and carries the new shape information for
+	any previously reported, or new touch points of that frame.
+
+	Other events describing the touch point such as wl_touch.down,
+	wl_touch.motion or wl_touch.shape may be sent within the
+	same wl_touch.frame. A client should treat these events as a single
+	logical touch point update. The order of wl_touch.shape,
+	wl_touch.orientation and wl_touch.motion is not guaranteed.
+	A wl_touch.down event is guaranteed to occur before the first
+	wl_touch.orientation event for this touch ID but both events may occur
+	within the same wl_touch.frame.
+
+	The orientation describes the clockwise angle of a touchpoint's major
+	axis to the positive surface y-axis and is normalized to the -180 to
+	+180 degree range. The granularity of orientation depends on the touch
+	device, some devices only support binary rotation values between 0 and
+	90 degrees.
+
+	This event is only sent by the compositor if the touch device supports
+	orientation reports.
+      </description>
+      <arg name="id" type="int" summary="the unique ID of this touch point"/>
+      <arg name="orientation" type="fixed" summary="angle between major axis and positive surface y-axis in degrees"/>
     </event>
   </interface>
 
-  <interface name="wl_output" version="2">
+  <interface name="wl_output" version="4">
     <description summary="compositor output region">
       An output describes part of the compositor geometry.  The
       compositor works in the 'compositor coordinate system' and an
-      output corresponds to rectangular area in that space that is
+      output corresponds to a rectangular area in that space that is
       actually visible.  This typically corresponds to a monitor that
       displays part of the compositor space.  This object is published
       as global during start up, or when a monitor is hotplugged.
@@ -1636,39 +2773,37 @@
     <enum name="subpixel">
       <description summary="subpixel geometry information">
 	This enumeration describes how the physical
-	pixels on an output are layed out.
+	pixels on an output are laid out.
       </description>
-      <entry name="unknown" value="0"/>
-      <entry name="none" value="1"/>
-      <entry name="horizontal_rgb" value="2"/>
-      <entry name="horizontal_bgr" value="3"/>
-      <entry name="vertical_rgb" value="4"/>
-      <entry name="vertical_bgr" value="5"/>
+      <entry name="unknown" value="0" summary="unknown geometry"/>
+      <entry name="none" value="1" summary="no geometry"/>
+      <entry name="horizontal_rgb" value="2" summary="horizontal RGB"/>
+      <entry name="horizontal_bgr" value="3" summary="horizontal BGR"/>
+      <entry name="vertical_rgb" value="4" summary="vertical RGB"/>
+      <entry name="vertical_bgr" value="5" summary="vertical BGR"/>
     </enum>
 
     <enum name="transform">
-      <description summary="transform from framebuffer to output">
-	This describes the transform that a compositor will apply to a
-	surface to compensate for the rotation or mirroring of an
-	output device.
+      <description summary="transformation applied to buffer contents">
+	This describes transformations that clients and compositors apply to
+	buffer contents.
 
 	The flipped values correspond to an initial flip around a
 	vertical axis followed by rotation.
 
-	The purpose is mainly to allow clients render accordingly and
+	The purpose is mainly to allow clients to render accordingly and
 	tell the compositor, so that for fullscreen surfaces, the
 	compositor will still be able to scan out directly from client
 	surfaces.
       </description>
-
-      <entry name="normal" value="0"/>
-      <entry name="90" value="1"/>
-      <entry name="180" value="2"/>
-      <entry name="270" value="3"/>
-      <entry name="flipped" value="4"/>
-      <entry name="flipped_90" value="5"/>
-      <entry name="flipped_180" value="6"/>
-      <entry name="flipped_270" value="7"/>
+      <entry name="normal" value="0" summary="no transform"/>
+      <entry name="90" value="1" summary="90 degrees counter-clockwise"/>
+      <entry name="180" value="2" summary="180 degrees counter-clockwise"/>
+      <entry name="270" value="3" summary="270 degrees counter-clockwise"/>
+      <entry name="flipped" value="4" summary="180 degree flip around a vertical axis"/>
+      <entry name="flipped_90" value="5" summary="flip and rotate 90 degrees counter-clockwise"/>
+      <entry name="flipped_180" value="6" summary="flip and rotate 180 degrees counter-clockwise"/>
+      <entry name="flipped_270" value="7" summary="flip and rotate 270 degrees counter-clockwise"/>
     </enum>
 
     <event name="geometry">
@@ -1676,6 +2811,23 @@
 	The geometry event describes geometric properties of the output.
 	The event is sent when binding to the output object and whenever
 	any of the properties change.
+
+	The physical size can be set to zero if it doesn't make sense for this
+	output (e.g. for projectors or virtual outputs).
+
+	The geometry event will be followed by a done event (starting from
+	version 2).
+
+	Clients should use wl_surface.preferred_buffer_transform instead of the
+	transform advertised by this event to find the preferred buffer
+	transform to use for a surface.
+
+	Note: wl_output only advertises partial information about the output
+	position and identification. Some compositors, for instance those not
+	implementing a desktop-style output layout or those exposing virtual
+	outputs, might fake this information. Instead of using x and y, clients
+	should use xdg_output.logical_position. Instead of using make and model,
+	clients should use name and description.
       </description>
       <arg name="x" type="int"
 	   summary="x position within the global compositor space"/>
@@ -1685,17 +2837,17 @@
 	   summary="width in millimeters of the output"/>
       <arg name="physical_height" type="int"
 	   summary="height in millimeters of the output"/>
-      <arg name="subpixel" type="int"
+      <arg name="subpixel" type="int" enum="subpixel"
 	   summary="subpixel orientation of the output"/>
       <arg name="make" type="string"
 	   summary="textual description of the manufacturer"/>
       <arg name="model" type="string"
 	   summary="textual description of the model"/>
-      <arg name="transform" type="int"
-	   summary="transform that maps framebuffer to output"/>
+      <arg name="transform" type="int" enum="transform"
+	   summary="additional transformation applied to buffer contents during presentation"/>
     </event>
 
-    <enum name="mode">
+    <enum name="mode" bitfield="true">
       <description summary="mode information">
 	These flags describe properties of an output mode.
 	They are used in the flags bitfield of the mode event.
@@ -1716,35 +2868,58 @@
 	current.  In other words, the current mode is always the last
 	mode that was received with the current flag set.
 
+	Non-current modes are deprecated. A compositor can decide to only
+	advertise the current mode and never send other modes. Clients
+	should not rely on non-current modes.
+
 	The size of a mode is given in physical hardware units of
-        the output device. This is not necessarily the same as
-        the output size in the global compositor space. For instance,
-        the output may be scaled, as described in wl_output.scale,
-        or transformed , as described in wl_output.transform.
+	the output device. This is not necessarily the same as
+	the output size in the global compositor space. For instance,
+	the output may be scaled, as described in wl_output.scale,
+	or transformed, as described in wl_output.transform. Clients
+	willing to retrieve the output size in the global compositor
+	space should use xdg_output.logical_size instead.
+
+	The vertical refresh rate can be set to zero if it doesn't make
+	sense for this output (e.g. for virtual outputs).
+
+	The mode event will be followed by a done event (starting from
+	version 2).
+
+	Clients should not use the refresh rate to schedule frames. Instead,
+	they should use the wl_surface.frame event or the presentation-time
+	protocol.
+
+	Note: this information is not always meaningful for all outputs. Some
+	compositors, such as those exposing virtual outputs, might fake the
+	refresh rate or the size.
       </description>
-      <arg name="flags" type="uint" summary="bitfield of mode flags"/>
+      <arg name="flags" type="uint" enum="mode" summary="bitfield of mode flags"/>
       <arg name="width" type="int" summary="width of the mode in hardware units"/>
       <arg name="height" type="int" summary="height of the mode in hardware units"/>
       <arg name="refresh" type="int" summary="vertical refresh rate in mHz"/>
     </event>
 
+    <!-- Version 2 additions -->
+
     <event name="done" since="2">
       <description summary="sent all information about output">
-        This event is sent after all other properties has been
-        sent after binding to the output object and after any
-        other property changes done after that. This allows
-        changes to the output properties to be seen as
-        atomic, even if they happen via multiple events.
+	This event is sent after all other properties have been
+	sent after binding to the output object and after any
+	other property changes done after that. This allows
+	changes to the output properties to be seen as
+	atomic, even if they happen via multiple events.
       </description>
     </event>
 
     <event name="scale" since="2">
       <description summary="output scaling properties">
 	This event contains scaling geometry information
-        that is not in the geometry event. It may be sent after
-        binding the output object or if the output scale changes
-        later. If it is not sent, the client should assume a
-	scale of 1.
+	that is not in the geometry event. It may be sent after
+	binding the output object or if the output scale changes
+	later. The compositor will emit a non-zero, positive
+	value for scale. If it is not sent, the client should
+	assume a scale of 1.
 
 	A scale larger than 1 means that the compositor will
 	automatically scale surface buffers by this amount
@@ -1752,14 +2927,78 @@
 	displays where applications rendering at the native
 	resolution would be too small to be legible.
 
-	It is intended that scaling aware clients track the
-	current output of a surface, and if it is on a scaled
-	output it should use wl_surface.set_buffer_scale with
-	the scale of the output. That way the compositor can
-	avoid scaling the surface, and the client can supply
-	a higher detail image.
+	Clients should use wl_surface.preferred_buffer_scale
+	instead of this event to find the preferred buffer
+	scale to use for a surface.
+
+	The scale event will be followed by a done event.
       </description>
       <arg name="factor" type="int" summary="scaling factor of output"/>
+    </event>
+
+    <!-- Version 3 additions -->
+
+    <request name="release" type="destructor" since="3">
+      <description summary="release the output object">
+	Using this request a client can tell the server that it is not going to
+	use the output object anymore.
+      </description>
+    </request>
+
+    <!-- Version 4 additions -->
+
+    <event name="name" since="4">
+      <description summary="name of this output">
+	Many compositors will assign user-friendly names to their outputs, show
+	them to the user, allow the user to refer to an output, etc. The client
+	may wish to know this name as well to offer the user similar behaviors.
+
+	The name is a UTF-8 string with no convention defined for its contents.
+	Each name is unique among all wl_output globals. The name is only
+	guaranteed to be unique for the compositor instance.
+
+	The same output name is used for all clients for a given wl_output
+	global. Thus, the name can be shared across processes to refer to a
+	specific wl_output global.
+
+	The name is not guaranteed to be persistent across sessions, thus cannot
+	be used to reliably identify an output in e.g. configuration files.
+
+	Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+	not assume that the name is a reflection of an underlying DRM connector,
+	X11 connection, etc.
+
+	The name event is sent after binding the output object. This event is
+	only sent once per output object, and the name does not change over the
+	lifetime of the wl_output global.
+
+	Compositors may re-use the same output name if the wl_output global is
+	destroyed and re-created later. Compositors should avoid re-using the
+	same name if possible.
+
+	The name event will be followed by a done event.
+      </description>
+      <arg name="name" type="string" summary="output name"/>
+    </event>
+
+    <event name="description" since="4">
+      <description summary="human-readable description of this output">
+	Many compositors can produce human-readable descriptions of their
+	outputs. The client may wish to know this description as well, e.g. for
+	output selection purposes.
+
+	The description is a UTF-8 string with no convention defined for its
+	contents. The description is not guaranteed to be unique among all
+	wl_output globals. Examples might include 'Foocorp 11" Display' or
+	'Virtual X11 output via :1'.
+
+	The description event is sent after binding the output object and
+	whenever the description changes. The description is optional, and may
+	not be sent at all.
+
+	The description event will be followed by a done event.
+      </description>
+      <arg name="description" type="string" summary="output description"/>
     </event>
   </interface>
 
@@ -1781,24 +3020,21 @@
       <description summary="add rectangle to region">
 	Add the specified rectangle to the region.
       </description>
-
-      <arg name="x" type="int"/>
-      <arg name="y" type="int"/>
-      <arg name="width" type="int"/>
-      <arg name="height" type="int"/>
+      <arg name="x" type="int" summary="region-local x coordinate"/>
+      <arg name="y" type="int" summary="region-local y coordinate"/>
+      <arg name="width" type="int" summary="rectangle width"/>
+      <arg name="height" type="int" summary="rectangle height"/>
     </request>
 
     <request name="subtract">
       <description summary="subtract rectangle from region">
 	Subtract the specified rectangle from the region.
       </description>
-
-      <arg name="x" type="int"/>
-      <arg name="y" type="int"/>
-      <arg name="width" type="int"/>
-      <arg name="height" type="int"/>
+      <arg name="x" type="int" summary="region-local x coordinate"/>
+      <arg name="y" type="int" summary="region-local y coordinate"/>
+      <arg name="width" type="int" summary="rectangle width"/>
+      <arg name="height" type="int" summary="rectangle height"/>
     </request>
-
   </interface>
 
   <interface name="wl_subcompositor" version="1">
@@ -1834,7 +3070,9 @@
 
     <enum name="error">
       <entry name="bad_surface" value="0"
-             summary="the to-be sub-surface is invalid"/>
+	     summary="the to-be sub-surface is invalid"/>
+      <entry name="bad_parent" value="1"
+	     summary="the to-be sub-surface parent is invalid"/>
     </enum>
 
     <request name="get_subsurface">
@@ -1843,17 +3081,28 @@
 	associate it with the given parent surface. This turns a
 	plain wl_surface into a sub-surface.
 
-	The to-be sub-surface must not already have a dedicated
-	purpose, like any shell surface type, cursor image, drag icon,
-	or sub-surface. Otherwise a protocol error is raised.
-      </description>
+	The to-be sub-surface must not already have another role, and it
+	must not have an existing wl_subsurface object. Otherwise the
+	bad_surface protocol error is raised.
 
+	Adding sub-surfaces to a parent is a double-buffered operation on the
+	parent (see wl_surface.commit). The effect of adding a sub-surface
+	becomes visible on the next time the state of the parent surface is
+	applied.
+
+	The parent surface must not be one of the child surface's descendants,
+	and the parent must be different from the child surface, otherwise the
+	bad_parent protocol error is raised.
+
+	This request modifies the behaviour of wl_surface.commit request on
+	the sub-surface, see the documentation on wl_subsurface interface.
+      </description>
       <arg name="id" type="new_id" interface="wl_subsurface"
-           summary="the new subsurface object id"/>
+	   summary="the new sub-surface object ID"/>
       <arg name="surface" type="object" interface="wl_surface"
-           summary="the surface to be turned into a sub-surface"/>
+	   summary="the surface to be turned into a sub-surface"/>
       <arg name="parent" type="object" interface="wl_surface"
-           summary="the parent surface"/>
+	   summary="the parent surface"/>
     </request>
   </interface>
 
@@ -1871,7 +3120,7 @@
       hidden, or if a NULL wl_buffer is applied. These rules apply
       recursively through the tree of surfaces.
 
-      The behaviour of wl_surface.commit request on a sub-surface
+      The behaviour of a wl_surface.commit request on a sub-surface
       depends on the sub-surface's mode. The possible modes are
       synchronized and desynchronized, see methods
       wl_subsurface.set_sync and wl_subsurface.set_desync. Synchronized
@@ -1880,7 +3129,7 @@
       wl_surface state directly. A sub-surface is initially in the
       synchronized mode.
 
-      Sub-surfaces have also other kind of state, which is managed by
+      Sub-surfaces also have another kind of state, which is managed by
       wl_subsurface requests, as opposed to wl_surface requests. This
       state includes the sub-surface position relative to the parent
       surface (wl_subsurface.set_position), and the stacking order of
@@ -1899,42 +3148,44 @@
       synchronized mode, and then assume that all its child and grand-child
       sub-surfaces are synchronized, too, without explicitly setting them.
 
-      If the wl_surface associated with the wl_subsurface is destroyed, the
-      wl_subsurface object becomes inert. Note, that destroying either object
-      takes effect immediately. If you need to synchronize the removal
-      of a sub-surface to the parent surface update, unmap the sub-surface
-      first by attaching a NULL wl_buffer, update parent, and then destroy
-      the sub-surface.
+      Destroying a sub-surface takes effect immediately. If you need to
+      synchronize the removal of a sub-surface to the parent surface update,
+      unmap the sub-surface first by attaching a NULL wl_buffer, update parent,
+      and then destroy the sub-surface.
 
       If the parent wl_surface object is destroyed, the sub-surface is
       unmapped.
+
+      A sub-surface never has the keyboard focus of any seat.
+
+      The wl_surface.offset request is ignored: clients must use set_position
+      instead to move the sub-surface.
     </description>
 
     <request name="destroy" type="destructor">
       <description summary="remove sub-surface interface">
 	The sub-surface interface is removed from the wl_surface object
-	that was turned into a sub-surface with
+	that was turned into a sub-surface with a
 	wl_subcompositor.get_subsurface request. The wl_surface's association
-	to the parent is deleted, and the wl_surface loses its role as
-	a sub-surface. The wl_surface is unmapped.
+	to the parent is deleted. The wl_surface is unmapped immediately.
       </description>
     </request>
 
     <enum name="error">
       <entry name="bad_surface" value="0"
-             summary="wl_surface is not a sibling or the parent"/>
+	     summary="wl_surface is not a sibling or the parent"/>
     </enum>
 
     <request name="set_position">
       <description summary="reposition the sub-surface">
 	This schedules a sub-surface position change.
-	The sub-surface will be moved so, that its origin (top-left
+	The sub-surface will be moved so that its origin (top left
 	corner pixel) will be at the location x, y of the parent surface
 	coordinate system. The coordinates are not restricted to the parent
 	surface area. Negative values are allowed.
 
-	The next wl_surface.commit on the parent surface will reset
-	the sub-surface's position to the scheduled coordinates.
+	The scheduled coordinates will take effect whenever the state of the
+	parent surface is applied.
 
 	If more than one set_position request is invoked by the client before
 	the commit of the parent surface, the position of a new request always
@@ -1942,9 +3193,8 @@
 
 	The initial position is 0, 0.
       </description>
-
-      <arg name="x" type="int" summary="coordinate in the parent surface"/>
-      <arg name="y" type="int" summary="coordinate in the parent surface"/>
+      <arg name="x" type="int" summary="x coordinate in the parent surface"/>
+      <arg name="y" type="int" summary="y coordinate in the parent surface"/>
     </request>
 
     <request name="place_above">
@@ -1956,32 +3206,30 @@
 	will cause a protocol error.
 
 	The z-order is double-buffered. Requests are handled in order and
-	applied immediately to a pending state, then committed to the active
-	state on the next commit of the parent surface.
-	See wl_surface.commit and wl_subcompositor.get_subsurface.
+	applied immediately to a pending state. The final pending state is
+	copied to the active state the next time the state of the parent
+	surface is applied.
 
 	A new sub-surface is initially added as the top-most in the stack
 	of its siblings and parent.
       </description>
-
       <arg name="sibling" type="object" interface="wl_surface"
-           summary="the reference surface"/>
+	   summary="the reference surface"/>
     </request>
 
     <request name="place_below">
       <description summary="restack the sub-surface">
-	The sub-surface is placed just below of the reference surface.
+	The sub-surface is placed just below the reference surface.
 	See wl_subsurface.place_above.
       </description>
-
       <arg name="sibling" type="object" interface="wl_surface"
-           summary="the reference surface"/>
+	   summary="the reference surface"/>
     </request>
 
     <request name="set_sync">
       <description summary="set sub-surface to synchronized mode">
 	Change the commit behaviour of the sub-surface to synchronized
-	mode, also described as the parent dependant mode.
+	mode, also described as the parent dependent mode.
 
 	In synchronized mode, wl_surface.commit on a sub-surface will
 	accumulate the committed state in a cache, but the state will
@@ -2009,7 +3257,7 @@
 
 	If cached state exists when wl_surface.commit is called in
 	desynchronized mode, the pending state is added to the cached
-	state, and applied as whole. This invalidates the cache.
+	state, and applied as a whole. This invalidates the cache.
 
 	Note: even if a sub-surface is set to desynchronized, a parent
 	sub-surface may override it to behave as synchronized. For details,
@@ -2019,7 +3267,33 @@
 	the cached state is applied on set_desync.
       </description>
     </request>
+  </interface>
 
+  <interface name="wl_fixes" version="1">
+    <description summary="wayland protocol fixes">
+      This global fixes problems with other core-protocol interfaces that
+      cannot be fixed in these interfaces themselves.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroys this object"/>
+    </request>
+
+    <request name="destroy_registry">
+      <description summary="destroy a wl_registry">
+	This request destroys a wl_registry object.
+
+	The client should no longer use the wl_registry after making this
+	request.
+
+	The compositor will emit a wl_display.delete_id event with the object ID
+	of the registry and will no longer emit any events on the registry. The
+	client should re-use the object ID once it receives the
+	wl_display.delete_id event.
+      </description>
+      <arg name="registry" type="object" interface="wl_registry"
+	   summary="the registry to destroy"/>
+    </request>
   </interface>
 
 </protocol>

--- a/src/compositor/wayland_wrapper/qwlcompositor.cpp
+++ b/src/compositor/wayland_wrapper/qwlcompositor.cpp
@@ -194,7 +194,7 @@ void Compositor::init()
     if (socketArg != -1 && socketArg + 1 < arguments.size())
         m_socket_name = arguments.at(socketArg + 1).toLocal8Bit();
 
-    wl_compositor::init(m_display->handle(), 3);
+    wl_compositor::init(m_display->handle(), 4);
     wl_subcompositor::init(m_display->handle(), 1);
 
     m_data_device_manager =  new DataDeviceManager(this);

--- a/src/compositor/wayland_wrapper/qwldatadevice.cpp
+++ b/src/compositor/wayland_wrapper/qwldatadevice.cpp
@@ -72,12 +72,12 @@ DataDevice::DataDevice(InputDevice *inputDevice)
 {
 }
 
-void DataDevice::setFocus(QtWaylandServer::wl_keyboard::Resource *focusResource)
+void DataDevice::setFocus(Surface *focusSurface)
 {
-    if (!focusResource)
+    if (!focusSurface)
         return;
 
-    Resource *resource = resourceMap().value(focusResource->client());
+    Resource *resource = resourceMap().value(focusSurface->resource()->client());
 
     if (!resource)
         return;
@@ -208,8 +208,8 @@ void DataDevice::data_device_set_selection(Resource *, struct ::wl_resource *sou
     if (m_selectionSource)
         m_selectionSource->setDevice(this);
 
-    QtWaylandServer::wl_keyboard::Resource *focusResource = m_inputDevice->keyboardDevice()->focusResource();
-    Resource *resource = focusResource ? resourceMap().value(focusResource->client()) : 0;
+    Surface *focusSurface = m_inputDevice->keyboardDevice()->focus();
+    Resource *resource = focusSurface ? resourceMap().value(focusSurface->resource()->client()) : 0;
 
     if (resource && m_selectionSource) {
         DataOffer *offer = new DataOffer(m_selectionSource, resource);

--- a/src/compositor/wayland_wrapper/qwldatadevice_p.h
+++ b/src/compositor/wayland_wrapper/qwldatadevice_p.h
@@ -71,7 +71,7 @@ class DataDevice : public QtWaylandServer::wl_data_device, public PointerGrabber
 public:
     DataDevice(InputDevice *inputDevice);
 
-    void setFocus(QtWaylandServer::wl_keyboard::Resource *focusResource);
+    void setFocus(Surface *focusSurface);
 
     void setDragFocus(QWaylandSurfaceView *focus, const QPointF &localPosition);
 

--- a/src/compositor/wayland_wrapper/qwlinputdevice.cpp
+++ b/src/compositor/wayland_wrapper/qwlinputdevice.cpp
@@ -306,7 +306,7 @@ bool InputDevice::setKeyboardFocus(Surface *surface)
     if (!m_keyboard.isNull()) {
         m_keyboard->setFocus(surface);
         if (m_data_device)
-            m_data_device->setFocus(m_keyboard->focusResource());
+            m_data_device->setFocus(surface);
         return true;
     }
     return false;

--- a/src/compositor/wayland_wrapper/qwlkeyboard.cpp
+++ b/src/compositor/wayland_wrapper/qwlkeyboard.cpp
@@ -64,7 +64,6 @@ Keyboard::Keyboard(Compositor *compositor, InputDevice *seat)
     , m_seat(seat)
     , m_grab(this)
     , m_focus()
-    , m_focusResource()
     , m_keys()
     , m_modsDepressed()
     , m_modsLatched()
@@ -118,18 +117,13 @@ KeyboardGrabber *Keyboard::currentGrab() const
 
 void Keyboard::checkFocusResource(wl_keyboard::Resource *keyboardResource)
 {
-    if (!keyboardResource || !m_focus)
-        return;
-
-    // this is already the current  resource, do no send enter twice
-    if (m_focusResource == keyboardResource)
+    if (!m_focus)
         return;
 
     // check if new wl_keyboard resource is from the client owning the focus surface
     struct ::wl_client *focusedClient = m_focus->resource()->client();
     if (focusedClient == keyboardResource->client()) {
         sendEnter(m_focus, keyboardResource);
-        m_focusResource = keyboardResource;
     }
 }
 
@@ -143,23 +137,21 @@ void Keyboard::sendEnter(Surface *surface, wl_keyboard::Resource *keyboardResour
 void Keyboard::focused(Surface *surface)
 {
     if (m_focus != surface) {
-        if (m_focusResource) {
-            uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
-            send_leave(m_focusResource->handle, serial, m_focus->resource()->handle);
+        if (m_focus) {
+            for (Resource *res : resourceMap().values(m_focus->resource()->client())) {
+                uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
+                send_leave(res->handle, serial, m_focus->resource()->handle);
+            }
         }
         m_focusDestroyListener.reset();
         if (surface) {
             m_focusDestroyListener.listenForDestruction(surface->resource()->handle);
+            for (Resource *res : resourceMap().values(surface->resource()->client())) {
+                sendEnter(surface, res);
+            }
         }
     }
 
-    Resource *resource = surface ? resourceMap().value(surface->resource()->client()) : 0;
-
-    if (resource && (m_focus != surface || m_focusResource != resource)) {
-        sendEnter(surface, resource);
-    }
-
-    m_focusResource = resource;
     m_focus = surface;
     Q_EMIT focusChanged(m_focus);
 }
@@ -188,7 +180,6 @@ void Keyboard::focusDestroyed(void *data)
     m_focusDestroyListener.reset();
 
     m_focus = 0;
-    m_focusResource = 0;
 }
 
 void Keyboard::sendKeyModifiers(wl_keyboard::Resource *resource, uint32_t serial)
@@ -211,11 +202,6 @@ Surface *Keyboard::focus() const
     return m_focus;
 }
 
-QtWaylandServer::wl_keyboard::Resource *Keyboard::focusResource() const
-{
-    return m_focusResource;
-}
-
 void Keyboard::keyboard_bind_resource(wl_keyboard::Resource *resource)
 {
 #ifndef QT_NO_WAYLAND_XKB
@@ -235,12 +221,6 @@ void Keyboard::keyboard_bind_resource(wl_keyboard::Resource *resource)
     checkFocusResource(resource);
 }
 
-void Keyboard::keyboard_destroy_resource(wl_keyboard::Resource *resource)
-{
-    if (m_focusResource == resource)
-        m_focusResource = 0;
-}
-
 void Keyboard::keyboard_release(wl_keyboard::Resource *resource)
 {
     wl_resource_destroy(resource->handle);
@@ -248,8 +228,10 @@ void Keyboard::keyboard_release(wl_keyboard::Resource *resource)
 
 void Keyboard::key(uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
 {
-    if (m_focusResource) {
-        send_key(m_focusResource->handle, serial, time, key, state);
+    if (m_focus) {
+        for (Resource *res : resourceMap().values(m_focus->resource()->client())) {
+            send_key(res->handle, serial, time, key, state);
+        }
     }
 }
 
@@ -278,8 +260,10 @@ void Keyboard::sendKeyEvent(uint code, uint32_t state)
 void Keyboard::modifiers(uint32_t serial, uint32_t mods_depressed,
                          uint32_t mods_latched, uint32_t mods_locked, uint32_t group)
 {
-    if (m_focusResource) {
-        send_modifiers(m_focusResource->handle, serial, mods_depressed, mods_latched, mods_locked, group);
+    if (m_focus) {
+        for (Resource *res : resourceMap().values(m_focus->resource()->client())) {
+            send_modifiers(res->handle, serial, mods_depressed, mods_latched, mods_locked, group);
+        }
     }
 }
 
@@ -332,8 +316,12 @@ void Keyboard::updateKeymap()
     }
 
     xkb_state_update_mask(m_state, 0, m_modsLatched, m_modsLocked, 0, 0, 0);
-    if (m_focusResource)
-        sendKeyModifiers(m_focusResource, wl_display_next_serial(m_compositor->wl_display()));
+    uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
+    if (m_focus) {
+        for (Resource *res : resourceMap().values(m_focus->resource()->client())) {
+            sendKeyModifiers(res, serial);
+        }
+    }
 #endif
 }
 

--- a/src/compositor/wayland_wrapper/qwlkeyboard_p.h
+++ b/src/compositor/wayland_wrapper/qwlkeyboard_p.h
@@ -103,7 +103,6 @@ public:
     void sendKeyReleaseEvent(uint code);
 
     Surface *focus() const;
-    Resource *focusResource() const;
 
     void focused(Surface* surface);
     void key(uint32_t serial, uint32_t time, uint32_t key, uint32_t state);
@@ -128,7 +127,6 @@ Q_SIGNALS:
 
 protected:
     void keyboard_bind_resource(Resource *resource);
-    void keyboard_destroy_resource(Resource *resource);
     void keyboard_release(Resource *resource) Q_DECL_OVERRIDE;
 
 private:
@@ -149,7 +147,6 @@ private:
 
     KeyboardGrabber* m_grab;
     Surface *m_focus;
-    Resource *m_focusResource;
     WlListener m_focusDestroyListener;
 
     QVector<uint32_t> m_keys;

--- a/src/compositor/wayland_wrapper/qwlpointer.cpp
+++ b/src/compositor/wayland_wrapper/qwlpointer.cpp
@@ -53,6 +53,7 @@ QT_BEGIN_NAMESPACE
 namespace QtWayland {
 
 using QtWaylandServer::wl_keyboard;
+using QtWaylandServer::wl_surface;
 
 static uint32_t toWaylandButton(Qt::MouseButton button)
 {
@@ -94,7 +95,6 @@ Pointer::Pointer(Compositor *compositor, InputDevice *seat)
     , m_grabSerial()
     , m_position(100, 100)
     , m_focus()
-    , m_focusResource()
     , m_current()
     , m_currentPoint()
     , m_buttonCount()
@@ -104,29 +104,33 @@ Pointer::Pointer(Compositor *compositor, InputDevice *seat)
 
 void Pointer::setFocus(QWaylandSurfaceView *surface, const QPointF &position)
 {
-    if (m_focusResource && m_focus != surface) {
+    if (m_focus && m_focus != surface) {
+        wl_surface::Resource *surfaceResource = m_focus->surface()->handle()->resource();
         uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
-        send_leave(m_focusResource->handle, serial, m_focus->surface()->handle()->resource()->handle);
+        for (Resource *res : resourceMap().values(surfaceResource->client())) {
+            send_leave(res->handle, serial, surfaceResource->handle);
+        }
         m_focusDestroyListener.reset();
     }
 
-    Resource *resource = surface ? resourceMap().value(surface->surface()->handle()->resource()->client()) : 0;
-
-    if (resource && (m_focus != surface || resource != m_focusResource)) {
+    if (surface && m_focus != surface) {
+        wl_surface::Resource *surfaceResource = surface->surface()->handle()->resource();
         uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
         Keyboard *keyboard = m_seat->keyboardDevice();
         if (keyboard) {
-            wl_keyboard::Resource *kr = keyboard->resourceMap().value(surface->surface()->handle()->resource()->client());
-            if (kr)
+            for (wl_keyboard::Resource *kr : keyboard->resourceMap().values(surfaceResource->client())) {
                 keyboard->sendKeyModifiers(kr, serial);
+            }
         }
-        send_enter(resource->handle, serial, surface->surface()->handle()->resource()->handle,
-                   wl_fixed_from_double(position.x()), wl_fixed_from_double(position.y()));
 
-        m_focusDestroyListener.listenForDestruction(surface->surface()->handle()->resource()->handle);
+        for (Resource *res : resourceMap().values(surfaceResource->client())) {
+            send_enter(res->handle, serial, surfaceResource->handle,
+                       wl_fixed_from_double(position.x()), wl_fixed_from_double(position.y()));
+        }
+
+        m_focusDestroyListener.listenForDestruction(surfaceResource->handle);
     }
 
-    m_focusResource = resource;
     m_focus = surface;
 }
 
@@ -136,7 +140,6 @@ void Pointer::focusDestroyed(void *data)
     m_focusDestroyListener.reset();
 
     m_focus = 0;
-    m_focusResource = 0;
     setMouseFocus(0, QPointF(), QPointF());
 }
 
@@ -206,17 +209,6 @@ QPointF Pointer::currentPosition() const
     return m_currentPoint;
 }
 
-QtWaylandServer::wl_pointer::Resource *Pointer::focusResource() const
-{
-    return m_focusResource;
-}
-
-void Pointer::pointer_destroy_resource(wl_pointer::Resource *resource)
-{
-    if (m_focusResource == resource)
-        m_focusResource = 0;
-}
-
 void Pointer::pointer_release(wl_pointer::Resource *resource)
 {
     wl_resource_destroy(resource->handle);
@@ -235,7 +227,9 @@ void Pointer::setMouseFocus(QWaylandSurfaceView *surface, const QPointF &localPo
 void Pointer::sendButton(uint32_t time, Qt::MouseButton button, uint32_t state)
 {
     uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
-    send_button(m_focusResource->handle, serial, time, toWaylandButton(button), state);
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_button(res->handle, serial, time, toWaylandButton(button), state);
+    }
 }
 
 void Pointer::sendMousePressEvent(Qt::MouseButton button, const QPointF &localPos, const QPointF &globalPos)
@@ -276,13 +270,15 @@ void Pointer::sendMouseMoveEvent(const QPointF &localPos, const QPointF &globalP
 
 void Pointer::sendMouseWheelEvent(Qt::Orientation orientation, int delta)
 {
-    if (!m_focusResource)
+    if (!m_focus)
         return;
 
     uint32_t time = m_compositor->currentTimeMsecs();
     uint32_t axis = orientation == Qt::Horizontal ? WL_POINTER_AXIS_HORIZONTAL_SCROLL
                                                   : WL_POINTER_AXIS_VERTICAL_SCROLL;
-    send_axis(m_focusResource->handle, time, axis, wl_fixed_from_int(-delta / 12));
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_axis(res->handle, time, axis, wl_fixed_from_int(-delta / 12));
+    }
 }
 
 void Pointer::focus()
@@ -295,16 +291,19 @@ void Pointer::focus()
 
 void Pointer::motion(uint32_t time)
 {
-    if (m_focusResource)
-        send_motion(m_focusResource->handle, time,
+    if (!m_focus)
+        return;
+
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_motion(res->handle, time,
                     wl_fixed_from_double(m_currentPoint.x()),
                     wl_fixed_from_double(m_currentPoint.y()));
-
+    }
 }
 
 void Pointer::button(uint32_t time, Qt::MouseButton button, uint32_t state)
 {
-    if (m_focusResource) {
+    if (m_focus) {
         sendButton(time, button, state);
     }
 

--- a/src/compositor/wayland_wrapper/qwlpointer_p.h
+++ b/src/compositor/wayland_wrapper/qwlpointer_p.h
@@ -115,7 +115,6 @@ public:
     QWaylandSurfaceView *current() const;
     QPointF position() const;
     QPointF currentPosition() const;
-    Resource *focusResource() const;
 
     bool buttonPressed() const;
 
@@ -126,7 +125,6 @@ public:
 protected:
     void pointer_set_cursor(Resource *resource, uint32_t serial, wl_resource *surface, int32_t hotspot_x, int32_t hotspot_y) Q_DECL_OVERRIDE;
     void pointer_release(Resource *resource) Q_DECL_OVERRIDE;
-    void pointer_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
 
 private:
     void focusDestroyed(void *data);
@@ -142,7 +140,6 @@ private:
     QPointF m_position;
 
     QWaylandSurfaceView *m_focus;
-    Resource *m_focusResource;
 
     QWaylandSurfaceView *m_current;
     QPointF m_currentPoint;

--- a/src/compositor/wayland_wrapper/qwlshellsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlshellsurface.cpp
@@ -544,7 +544,7 @@ void ShellSurfacePopupGrabber::motion(uint32_t time)
 
 void ShellSurfacePopupGrabber::button(uint32_t time, Qt::MouseButton button, uint32_t state)
 {
-    if (m_pointer->focusResource()) {
+    if (m_pointer->focusSurface()) {
         m_pointer->sendButton(time, button, state);
     } else if (state == QtWaylandServer::wl_pointer::button_state_pressed &&
                (m_initialUp || time - m_pointer->grabTime() > 500) &&

--- a/src/compositor/wayland_wrapper/qwlsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlsurface.cpp
@@ -483,6 +483,16 @@ void Surface::surface_attach(Resource *, struct wl_resource *buffer, int x, int 
 
 void Surface::surface_damage(Resource *, int32_t x, int32_t y, int32_t width, int32_t height)
 {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+    Q_UNUSED(width);
+    Q_UNUSED(height);
+    // Ignore surface-local damage and damage the entire surface instead.
+    m_pending.damage = infiniteRegion();
+}
+
+void Surface::surface_damage_buffer(Resource *, int32_t x, int32_t y, int32_t width, int32_t height)
+{
     m_pending.damage = m_pending.damage.united(QRect(x, y, width, height));
 }
 

--- a/src/compositor/wayland_wrapper/qwlsurface_p.h
+++ b/src/compositor/wayland_wrapper/qwlsurface_p.h
@@ -190,6 +190,8 @@ protected:
                                   struct wl_resource *region) Q_DECL_OVERRIDE;
     void surface_commit(Resource *resource) Q_DECL_OVERRIDE;
     void surface_set_buffer_transform(Resource *resource, int32_t transform) Q_DECL_OVERRIDE;
+    void surface_damage_buffer(Resource *resource,
+                               int32_t x, int32_t y, int32_t width, int32_t height) Q_DECL_OVERRIDE;
 
     Q_DISABLE_COPY(Surface)
 

--- a/src/compositor/wayland_wrapper/qwltouch.cpp
+++ b/src/compositor/wayland_wrapper/qwltouch.cpp
@@ -49,11 +49,12 @@ QT_BEGIN_NAMESPACE
 
 namespace QtWayland {
 
+using QtWaylandServer::wl_surface;
+
 Touch::Touch(Compositor *compositor)
     : wl_touch()
     , m_compositor(compositor)
     , m_focus()
-    , m_focusResource()
     , m_grab(this)
 {
     m_grab->setTouch(this);
@@ -67,7 +68,6 @@ void Touch::setFocus(QWaylandSurfaceView *surface)
         m_focusDestroyListener.listenForDestruction(surface->surface()->handle()->resource()->handle);
 
     m_focus = surface;
-    m_focusResource = surface ? resourceMap().value(surface->surface()->handle()->resource()->client()) : 0;
 }
 
 void Touch::startGrab(TouchGrabber *grab)
@@ -87,13 +87,6 @@ void Touch::focusDestroyed(void *data)
     m_focusDestroyListener.reset();
 
     m_focus = 0;
-    m_focusResource = 0;
-}
-
-void Touch::touch_destroy_resource(Resource *resource)
-{
-    if (m_focusResource == resource)
-        m_focusResource = 0;
 }
 
 void Touch::touch_release(Resource *resource)
@@ -103,14 +96,22 @@ void Touch::touch_release(Resource *resource)
 
 void Touch::sendCancel()
 {
-    if (m_focusResource)
-        send_cancel(m_focusResource->handle);
+    if (!m_focus)
+        return;
+
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_cancel(res->handle);
+    }
 }
 
 void Touch::sendFrame()
 {
-    if (m_focusResource)
-        send_frame(m_focusResource->handle);
+    if (!m_focus)
+        return;
+
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_frame(res->handle);
+    }
 }
 
 void Touch::sendDown(int touch_id, const QPointF &position)
@@ -130,32 +131,40 @@ void Touch::sendUp(int touch_id)
 
 void Touch::down(uint32_t time, int touch_id, const QPointF &position)
 {
-    if (!m_focusResource || !m_focus)
+    if (!m_focus)
         return;
+
+    wl_surface::Resource *surfaceResource = m_focus->surface()->handle()->resource();
 
     uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
 
-    send_down(m_focusResource->handle, serial, time, m_focus->surface()->handle()->resource()->handle, touch_id,
-              wl_fixed_from_double(position.x()), wl_fixed_from_double(position.y()));
+    for (Resource *res : resourceMap().values(surfaceResource->client())) {
+        send_down(res->handle, serial, time, surfaceResource->handle, touch_id,
+                  wl_fixed_from_double(position.x()), wl_fixed_from_double(position.y()));
+    }
 }
 
 void Touch::up(uint32_t time, int touch_id)
 {
-    if (!m_focusResource)
+    if (!m_focus)
         return;
 
     uint32_t serial = wl_display_next_serial(m_compositor->wl_display());
 
-    send_up(m_focusResource->handle, serial, time, touch_id);
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_up(res->handle, serial, time, touch_id);
+    }
 }
 
 void Touch::motion(uint32_t time, int touch_id, const QPointF &position)
 {
-    if (!m_focusResource)
+    if (!m_focus)
         return;
 
-    send_motion(m_focusResource->handle, time, touch_id,
-                wl_fixed_from_double(position.x()), wl_fixed_from_double(position.y()));
+    for (Resource *res : resourceMap().values(m_focus->surface()->handle()->resource()->client())) {
+        send_motion(res->handle, time, touch_id,
+                    wl_fixed_from_double(position.x()), wl_fixed_from_double(position.y()));
+    }
 }
 
 TouchGrabber::TouchGrabber()

--- a/src/compositor/wayland_wrapper/qwltouch_p.h
+++ b/src/compositor/wayland_wrapper/qwltouch_p.h
@@ -112,13 +112,11 @@ public:
 
 private:
     void focusDestroyed(void *data);
-    void touch_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
     void touch_release(Resource *resource) Q_DECL_OVERRIDE;
 
     Compositor *m_compositor;
 
     QWaylandSurfaceView *m_focus;
-    Resource *m_focusResource;
     WlListener m_focusDestroyListener;
 
     TouchGrabber *m_grab;


### PR DESCRIPTION
Implement some missing standard features that Firefox needs to work:
 - Wayland compositor protocol version 4 with `damage_buffer` request
 - Allow using multiple `wl_keyboard`, `wl_pointer` and `wl_touch` objects simultaneously
 - Subsurface support is in a separate PR: #5 

Some other Wayland applications may benefit from this as well.

These changes aren't directly related to each other, so I'm open to separating them and having only some of them merged.