### PR TITLE
Don't crash if shm is not available

### DIFF
--- a/src/client/qwaylandcursor.cpp
+++ b/src/client/qwaylandcursor.cpp
@@ -50,6 +50,10 @@ namespace QtWaylandClient {
 QWaylandCursor::QWaylandCursor(QWaylandScreen *screen)
     : mDisplay(screen->display())
 {
+    if (!mDisplay->shm()) {
+        return;
+    }
+
     //TODO: Make wl_cursor_theme_load arguments configurable here
     QByteArray cursorTheme = qgetenv("XCURSOR_THEME");
     if (cursorTheme.isEmpty())


### PR DESCRIPTION
On native ports using mesa, shm may be null.  Dont crash in the cursor loading if this is the case.